### PR TITLE
Feature/ergonomic usage

### DIFF
--- a/examples/game_of_life.rs
+++ b/examples/game_of_life.rs
@@ -1,0 +1,73 @@
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
+use std::array;
+
+use console_display::{
+    console_display::ConsoleDisplay,
+    display_driver::{
+        DisplayDriver,
+        UpdateStatus,
+    },
+    pixel::monochrome_pixel::OctPixel,
+    pixel_display::StaticPixelDisplay,
+};
+use rand::{
+    Rng,
+    thread_rng,
+};
+
+fn main() {
+    let disp = StaticPixelDisplay::<OctPixel, 200, 100>::new_from_data(
+        &array::from_fn::<_, 20_000, _>(|_| {
+            let rng = thread_rng().gen_range(0..=1);
+            rng != 0
+        }),
+    );
+
+    let mut display = DisplayDriver::new(disp);
+
+    let offsets = [
+        (-1, -1),
+        (0, -1),
+        (1, -1),
+        (-1, 0),
+        (1, 0),
+        (-1, 1),
+        (0, 1),
+        (1, 1),
+    ];
+
+    display.set_target_frame_rate(30.);
+    display.set_on_update(move |disp, _| {
+        let mut data = disp.get_pixels();
+        for x in 0..disp.get_width() {
+            for y in 0..disp.get_height() {
+                let mut neighbors = 0;
+                for i in offsets {
+                    let x_i = (x as isize + i.0)
+                        .rem_euclid(disp.get_width() as isize)
+                        as usize;
+                    let y_i = (y as isize + i.1)
+                        .rem_euclid(disp.get_height() as isize)
+                        as usize;
+                    if disp
+                        .get_pixel(x_i, y_i)
+                        .expect("Could not get pixel.")
+                    {
+                        neighbors += 1;
+                    }
+                }
+                data[x + y * disp.get_width()] = neighbors == 3 ||
+                    neighbors == 2 &&
+                        disp.get_pixel(x, y)
+                            .expect("Could not get pixel.");
+            }
+        }
+        disp.set_pixels(&data);
+        UpdateStatus::Continue
+    });
+
+    display.initialize().expect("Could not initialize display.");
+    display.update();
+}

--- a/examples/image_render.rs
+++ b/examples/image_render.rs
@@ -9,11 +9,11 @@ use std::io::{
 use console_display::{
     display_driver::DisplayDriver,
     pixel::{
+        Pixel,
         color_pixel::{
             ColorOctPixel,
             RGBColor,
         },
-        monochrome_pixel::MultiPixel,
     },
     pixel_display::DynamicPixelDisplay,
 };

--- a/examples/snake.rs
+++ b/examples/snake.rs
@@ -23,7 +23,6 @@ use console_display::{
     },
     widget::two_widget::{
         OverlayWidget,
-        TwoWidget,
         VerticalTilingWidget,
     },
 };
@@ -96,7 +95,7 @@ fn main() {
         .unwrap(),
     );
 
-    let endscreen = disp.get_children_mut().1.get_children_mut().1;
+    let endscreen = &mut disp.1.1;
 
     for (i, sym) in "You lost".chars().enumerate() {
         endscreen
@@ -120,39 +119,32 @@ fn main() {
     let mut apple;
 
     {
-        let map_display = disp.get_children_mut().1;
+        let map_display = &mut disp.1;
 
         snake = vec![(
-            map_display.get_children().0.get_width() / 2,
-            map_display.get_children().0.get_height() / 2,
+            map_display.0.get_width() / 2,
+            map_display.0.get_height() / 2,
         )];
 
         map_display
-            .get_children_mut()
             .0
             .set_pixel(snake[0].0, snake[0].1, snake_color)
             .expect("Could not set pixel.");
 
         apple = (
-            rand::thread_rng()
-                .gen_range(0..map_display.get_children().0.get_width()),
-            rand::thread_rng()
-                .gen_range(0..map_display.get_children().0.get_height()),
+            rand::thread_rng().gen_range(0..map_display.0.get_width()),
+            rand::thread_rng().gen_range(0..map_display.0.get_height()),
         );
 
         while snake.contains(&apple) {
             apple = (
-                rand::thread_rng().gen_range(
-                    0..map_display.get_children().0.get_width(),
-                ),
-                rand::thread_rng().gen_range(
-                    0..map_display.get_children().0.get_height(),
-                ),
+                rand::thread_rng().gen_range(0..map_display.0.get_width()),
+                rand::thread_rng()
+                    .gen_range(0..map_display.0.get_height()),
             );
         }
 
         map_display
-            .get_children_mut()
             .0
             .set_pixel(apple.0, apple.1, apple_color)
             .expect("Could not set pixel.");
@@ -183,45 +175,41 @@ fn main() {
         }
 
         if lost {
-            disp.get_children_mut().1.set_child1_on_top(false);
+            disp.1.set_child1_on_top(false);
             return UpdateStatus::Continue;
         }
 
-        let map_display = disp.get_children_mut().1;
+        let map_display = &mut disp.1;
         // place new segment in front (direction) of snake head
         snake.insert(
             0,
             (
-                (snake[0].0 as i32 + direction.0).rem_euclid(
-                    map_display.get_children().0.get_width() as i32,
-                ) as usize,
-                (snake[0].1 as i32 + direction.1).rem_euclid(
-                    map_display.get_children().0.get_height() as i32,
-                ) as usize,
+                (snake[0].0 as i32 + direction.0)
+                    .rem_euclid(map_display.0.get_width() as i32)
+                    as usize,
+                (snake[0].1 as i32 + direction.1)
+                    .rem_euclid(map_display.0.get_height() as i32)
+                    as usize,
             ),
         );
 
         if snake[0] == apple {
             score += 1;
             if score ==
-                map_display.get_children().0.get_width() *
-                    map_display.get_children().0.get_height()
+                map_display.0.get_width() * map_display.0.get_height()
             {
                 return UpdateStatus::Break;
             }
             // place new apple
             while snake.contains(&apple) {
                 apple = (
-                    rand::thread_rng().gen_range(
-                        0..map_display.get_children().0.get_width(),
-                    ),
-                    rand::thread_rng().gen_range(
-                        0..map_display.get_children().0.get_height(),
-                    ),
+                    rand::thread_rng()
+                        .gen_range(0..map_display.0.get_width()),
+                    rand::thread_rng()
+                        .gen_range(0..map_display.0.get_height()),
                 );
             }
             map_display
-                .get_children_mut()
                 .0
                 .set_pixel(apple.0, apple.1, apple_color)
                 .expect("Could not set pixel.");
@@ -229,7 +217,6 @@ fn main() {
         else {
             // remove pixel at last segment of snake
             map_display
-                .get_children_mut()
                 .0
                 .set_pixel(
                     snake.last().unwrap().0,
@@ -243,7 +230,6 @@ fn main() {
 
         // place pixel at snake head
         map_display
-            .get_children_mut()
             .0
             .set_pixel(snake[0].0, snake[0].1, snake_color)
             .expect("Could not set pixel.");

--- a/examples/snake.rs
+++ b/examples/snake.rs
@@ -34,62 +34,7 @@ fn main() {
     let snake_color = RGBColor { r: 0, g: 255, b: 0 };
     let apple_color = RGBColor { r: 255, g: 0, b: 0 };
 
-    let mut disp = DisplayDriver::new(VerticalTilingWidget::new(
-        StaticPixelDisplay::<ColorSinglePixel, 100, 1>::new(RGBColor {
-            r: 255,
-            b: 255,
-            g: 255,
-        }),
-        OverlayWidget::new(
-            StaticPixelDisplay::<ColorDualPixel, 100, 42>::new(RGBColor {
-                r: 0,
-                b: 0,
-                g: 0,
-            }),
-            CharacterDisplay::<CharacterPixel, 100, 21>::build(
-                CharacterPixel::build(' ', Color::Default, Color::Default)
-                    .unwrap(),
-            )
-            .unwrap(),
-            true,
-        ),
-    ));
-
-    // This is bad because you rely on runtime checks.
-    let _ = DisplayDriver::new(
-        VerticalTilingWidget::build(
-            DynamicPixelDisplay::<ColorSinglePixel>::build(
-                100,
-                1,
-                RGBColor {
-                    r: 255,
-                    b: 255,
-                    g: 255,
-                },
-            )
-            .unwrap(),
-            OverlayWidget::build(
-                DynamicPixelDisplay::<ColorDualPixel>::build(
-                    100,
-                    42,
-                    RGBColor { r: 0, b: 0, g: 0 },
-                )
-                .unwrap(),
-                CharacterDisplay::<CharacterPixel, 100, 21>::build(
-                    CharacterPixel::build(
-                        ' ',
-                        Color::Default,
-                        Color::Default,
-                    )
-                    .unwrap(),
-                )
-                .unwrap(),
-                true,
-            )
-            .unwrap(),
-        )
-        .unwrap(),
-    );
+    let mut disp = construct_display();
 
     let endscreen = &mut disp.1.1;
 
@@ -241,4 +186,83 @@ fn main() {
 
     disp.initialize().expect("Could not initialize display.");
     disp.update();
+}
+
+type Display = DisplayDriver<
+    VerticalTilingWidget<
+        StaticPixelDisplay<ColorSinglePixel, 100, 1>,
+        OverlayWidget<
+            StaticPixelDisplay<ColorDualPixel, 100, 42>,
+            CharacterDisplay<CharacterPixel, 100, 21>,
+        >,
+    >,
+>;
+
+fn construct_display() -> Display {
+    DisplayDriver::new(VerticalTilingWidget::new(
+        StaticPixelDisplay::<ColorSinglePixel, 100, 1>::new(RGBColor {
+            r: 255,
+            b: 255,
+            g: 255,
+        }),
+        OverlayWidget::new(
+            StaticPixelDisplay::<ColorDualPixel, 100, 42>::new(RGBColor {
+                r: 0,
+                b: 0,
+                g: 0,
+            }),
+            CharacterDisplay::<CharacterPixel, 100, 21>::build(
+                CharacterPixel::build(' ', Color::Default, Color::Default)
+                    .unwrap(),
+            )
+            .unwrap(),
+            true,
+        ),
+    ))
+}
+
+type DisplayBad = DisplayDriver<
+    VerticalTilingWidget<
+        DynamicPixelDisplay<ColorSinglePixel>,
+        OverlayWidget<
+            DynamicPixelDisplay<ColorDualPixel>,
+            CharacterDisplay<CharacterPixel, 100, 21>,
+        >,
+    >,
+>;
+
+#[allow(dead_code)]
+fn construct_display_bad() -> DisplayBad {
+    DisplayDriver::new(
+        VerticalTilingWidget::build(
+            DynamicPixelDisplay::<ColorSinglePixel>::build(
+                100,
+                1,
+                RGBColor {
+                    r: 255,
+                    b: 255,
+                    g: 255,
+                },
+            ),
+            OverlayWidget::build(
+                DynamicPixelDisplay::<ColorDualPixel>::build(
+                    100,
+                    42,
+                    RGBColor { r: 0, b: 0, g: 0 },
+                ),
+                CharacterDisplay::<CharacterPixel, 100, 21>::build(
+                    CharacterPixel::build(
+                        ' ',
+                        Color::Default,
+                        Color::Default,
+                    )
+                    .unwrap(),
+                )
+                .unwrap(),
+                true,
+            )
+            .unwrap(),
+        )
+        .unwrap(),
+    )
 }

--- a/examples/snake.rs
+++ b/examples/snake.rs
@@ -192,8 +192,7 @@ fn main() {
 
         if snake[0] == apple {
             score += 1;
-            if score ==
-                map_display.get_width() * map_display.get_height()
+            if score == map_display.get_width() * map_display.get_height()
             {
                 return UpdateStatus::Break;
             }

--- a/examples/snake.rs
+++ b/examples/snake.rs
@@ -13,14 +13,10 @@ use console_display::{
         color_pixel::{
             Color,
             ColorDualPixel,
-            ColorSinglePixel,
             RGBColor,
         },
     },
-    pixel_display::{
-        DynamicPixelDisplay,
-        StaticPixelDisplay,
-    },
+    pixel_display::StaticPixelDisplay,
     widget::two_widget::{
         OverlayWidget,
         VerticalTilingWidget,
@@ -35,6 +31,21 @@ fn main() {
     let apple_color = RGBColor { r: 255, g: 0, b: 0 };
 
     let mut disp = construct_display();
+
+    let _ = disp.0.set_pixel(
+        99,
+        0,
+        &CharacterPixel::build(
+            '1',
+            Color::Color(RGBColor { r: 0, g: 0, b: 0 }),
+            Color::Color(RGBColor {
+                r: 255,
+                g: 255,
+                b: 255,
+            }),
+        )
+        .unwrap(),
+    );
 
     let endscreen = &mut disp.1.1;
 
@@ -137,6 +148,24 @@ fn main() {
 
         if snake[0] == apple {
             score += 1;
+            for (i, digit) in score.to_string().chars().rev().enumerate() {
+                let _ = disp.0.set_pixel(
+                    99 - i,
+                    0,
+                    &CharacterPixel::build(
+                        digit,
+                        Color::Color(RGBColor { r: 0, g: 0, b: 0 }),
+                        Color::Color(RGBColor {
+                            r: 255,
+                            g: 255,
+                            b: 255,
+                        }),
+                    )
+                    .unwrap(),
+                );
+            }
+
+            let map_display = &mut disp.1.0;
             if score == map_display.get_width() * map_display.get_height()
             {
                 return UpdateStatus::Break;
@@ -190,7 +219,7 @@ fn main() {
 
 type Display = DisplayDriver<
     VerticalTilingWidget<
-        StaticPixelDisplay<ColorSinglePixel, 100, 1>,
+        CharacterDisplay<CharacterPixel, 100, 1>,
         OverlayWidget<
             StaticPixelDisplay<ColorDualPixel, 100, 42>,
             CharacterDisplay<CharacterPixel, 100, 21>,
@@ -200,11 +229,19 @@ type Display = DisplayDriver<
 
 fn construct_display() -> Display {
     DisplayDriver::new(VerticalTilingWidget::new(
-        StaticPixelDisplay::<ColorSinglePixel, 100, 1>::new(RGBColor {
-            r: 255,
-            b: 255,
-            g: 255,
-        }),
+        CharacterDisplay::<_, 100, 1>::build(
+            CharacterPixel::build(
+                ' ',
+                Color::Color(RGBColor { r: 0, g: 0, b: 0 }),
+                Color::Color(RGBColor {
+                    r: 255,
+                    g: 255,
+                    b: 255,
+                }),
+            )
+            .unwrap(),
+        )
+        .unwrap(),
         OverlayWidget::new(
             StaticPixelDisplay::<ColorDualPixel, 100, 42>::new(RGBColor {
                 r: 0,
@@ -219,50 +256,4 @@ fn construct_display() -> Display {
             true,
         ),
     ))
-}
-
-type DisplayBad = DisplayDriver<
-    VerticalTilingWidget<
-        DynamicPixelDisplay<ColorSinglePixel>,
-        OverlayWidget<
-            DynamicPixelDisplay<ColorDualPixel>,
-            CharacterDisplay<CharacterPixel, 100, 21>,
-        >,
-    >,
->;
-
-#[allow(dead_code)]
-fn construct_display_bad() -> DisplayBad {
-    DisplayDriver::new(
-        VerticalTilingWidget::build(
-            DynamicPixelDisplay::<ColorSinglePixel>::build(
-                100,
-                1,
-                RGBColor {
-                    r: 255,
-                    b: 255,
-                    g: 255,
-                },
-            ),
-            OverlayWidget::build(
-                DynamicPixelDisplay::<ColorDualPixel>::build(
-                    100,
-                    42,
-                    RGBColor { r: 0, b: 0, g: 0 },
-                ),
-                CharacterDisplay::<CharacterPixel, 100, 21>::build(
-                    CharacterPixel::build(
-                        ' ',
-                        Color::Default,
-                        Color::Default,
-                    )
-                    .unwrap(),
-                )
-                .unwrap(),
-                true,
-            )
-            .unwrap(),
-        )
-        .unwrap(),
-    )
 }

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -13,7 +13,7 @@ use console_display::{
 fn main() {
     let mut char_disp: CharacterDisplay<CharacterPixel, 40, 20> =
         CharacterDisplay::build(
-            CharacterPixel::build(' ', Color::Default, Color::Default)
+            CharacterPixel::build('あ', Color::Default, Color::Default)
                 .unwrap(),
         )
         .unwrap();

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -3,7 +3,6 @@
 
 use console_display::{
     character_display::CharacterDisplay,
-    console_display::ConsoleDisplay,
     display_driver::DisplayDriver,
     pixel::{
         character_pixel::CharacterPixel,

--- a/src/display/character_display.rs
+++ b/src/display/character_display.rs
@@ -1,7 +1,6 @@
 use std::fmt::Display;
 
 use crate::{
-    console_display::ConsoleDisplay,
     pixel::{
         character_pixel::CharacterPixel,
         color_pixel::Color,
@@ -57,7 +56,7 @@ impl<const WIDTH: usize, const HEIGHT: usize>
     ) -> Result<Self, String> {
         let mut new_data = Vec::with_capacity(data.capacity());
         for i in data {
-            new_data.push(Some(i.clone()));
+            new_data.push(Some(i));
             for _ in 1..i.get_width() {
                 new_data.push(None);
             }
@@ -82,6 +81,14 @@ impl<const WIDTH: usize, const HEIGHT: usize>
     #[allow(dead_code)]
     const fn get_data_mut(&mut self) -> &mut Vec<Option<CharacterPixel>> {
         &mut self.data
+    }
+
+    pub const fn get_width(&self) -> usize {
+        WIDTH
+    }
+
+    pub const fn get_height(&self) -> usize {
+        HEIGHT
     }
 
     /// Returns the pixel value at the specified coordinates.
@@ -152,7 +159,7 @@ impl<const WIDTH: usize, const HEIGHT: usize>
         }
         self.data[x + y * WIDTH - overlap].clone_from(&default_pixel);
 
-        self.data[x + y * WIDTH] = Some(value.clone());
+        self.data[x + y * WIDTH] = Some(*value);
 
         let overlap = value.get_width();
         let mut max_overlap = value.get_width();
@@ -169,18 +176,6 @@ impl<const WIDTH: usize, const HEIGHT: usize>
         }
 
         Ok(())
-    }
-}
-
-impl<const WIDTH: usize, const HEIGHT: usize> ConsoleDisplay
-    for CharacterDisplay<CharacterPixel, WIDTH, HEIGHT>
-{
-    fn get_width(&self) -> usize {
-        WIDTH
-    }
-
-    fn get_height(&self) -> usize {
-        HEIGHT
     }
 }
 

--- a/src/display/character_display.rs
+++ b/src/display/character_display.rs
@@ -18,7 +18,7 @@ pub struct CharacterDisplay<
     const WIDTH: usize,
     const HEIGHT: usize,
 > {
-    data: Vec<CharacterPixel>,
+    data: Box<[CharacterPixel]>,
 }
 
 impl<const WIDTH: usize, const HEIGHT: usize>
@@ -37,7 +37,7 @@ impl<const WIDTH: usize, const HEIGHT: usize>
         &self.data
     }
 
-    fn get_data_mut(&mut self) -> &mut [CharacterPixel] {
+    fn get_data_mut(&mut self) -> &mut Box<[CharacterPixel]> {
         &mut self.data
     }
 }
@@ -109,14 +109,16 @@ impl<const WIDTH: usize, const HEIGHT: usize>
             ));
         }
 
-        Ok(Self { data: new_data })
+        Ok(Self {
+            data: new_data.into_boxed_slice(),
+        })
     }
 
-    pub const fn get_width(&self) -> usize {
+    #[must_use] pub const fn get_width(&self) -> usize {
         WIDTH
     }
 
-    pub const fn get_height(&self) -> usize {
+    #[must_use] pub const fn get_height(&self) -> usize {
         HEIGHT
     }
 

--- a/src/display/character_display.rs
+++ b/src/display/character_display.rs
@@ -206,8 +206,7 @@ impl<const WIDTH: usize, const HEIGHT: usize> Display
                 iter.next();
             }
         }
-        string_repr.pop();
-        string_repr.pop();
-        write!(f, "{string_repr}")
+
+        write!(f, "{}", string_repr.trim_end())
     }
 }

--- a/src/display/character_display.rs
+++ b/src/display/character_display.rs
@@ -114,11 +114,13 @@ impl<const WIDTH: usize, const HEIGHT: usize>
         })
     }
 
-    #[must_use] pub const fn get_width(&self) -> usize {
+    #[must_use]
+    pub const fn get_width(&self) -> usize {
         WIDTH
     }
 
-    #[must_use] pub const fn get_height(&self) -> usize {
+    #[must_use]
+    pub const fn get_height(&self) -> usize {
         HEIGHT
     }
 

--- a/src/display/console_display.rs
+++ b/src/display/console_display.rs
@@ -1,8 +1,215 @@
-use crate::widget::DynamicWidget;
+use crate::{
+    pixel::monochrome_pixel::MultiPixel,
+    widget::DynamicWidget,
+};
 
-pub trait ConsoleDisplay: DynamicWidget {
+pub trait ConsoleDisplay<T: MultiPixel>: DynamicWidget {
     /// Returns the width of the display in a display specific, individually addressable unit (e.g. pixels, characters).
     fn get_width(&self) -> usize;
     /// Returns the height of the display in a display specific, individually addressable unit (e.g. pixels, characters).
     fn get_height(&self) -> usize;
+
+    // TODO: Add proper double buffering.
+    /// Returns a vector containing all the pixels in the display.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the index of a pixel is out of bounds.
+    /// This should not happen and is subject to change in the future.
+    #[must_use]
+    fn get_pixels(&self) -> Vec<T::U>
+    where
+        [(); T::WIDTH * T::HEIGHT]:,
+    {
+        let mut pixels =
+            Vec::with_capacity(self.get_width() * self.get_height());
+        for x in 0..self.get_width() {
+            for y in 0..self.get_height() {
+                pixels.push(self.get_pixel(x, y).expect(
+                    "Invariant violated, pixel index out of range.",
+                ));
+            }
+        }
+        pixels
+    }
+
+    /// Sets the pixels of the display to the provided data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the provided data does not match the dimensions of the display.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the index of a pixel is out of bounds.
+    /// This should not happen and is subject to change in the future.
+    fn set_pixels(&mut self, data: &[T::U]) -> Result<(), String>
+    where
+        [(); T::WIDTH * T::HEIGHT]:,
+    {
+        if data.len() != self.get_width() * self.get_height() {
+            return Err(format!(
+                "Data does not match specified dimensions. Expected length of {}, got {}.",
+                self.get_width() * self.get_height(),
+                data.len()
+            ));
+        }
+        for x in 0..self.get_width() {
+            for y in 0..self.get_height() {
+                self.set_pixel(x, y, data[x + y * self.get_width()])
+                    .expect(
+                        "Invariant violated, pixel index out of range.",
+                    );
+            }
+        }
+        Ok(())
+    }
+
+    #[must_use]
+    fn get_data(&self) -> &[T];
+
+    fn get_data_mut(&mut self) -> &mut [T];
+
+    /// Returns a bool representing the state of the pixel at the specified coordinate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![allow(incomplete_features)]
+    /// #![feature(generic_const_exprs)]
+    ///
+    /// use console_display::{
+    ///     display_driver::DisplayDriver,
+    ///     pixel::monochrome_pixel::SinglePixel,
+    ///     pixel_display::DynamicPixelDisplay
+    /// };
+    ///
+    /// let disp: DisplayDriver<DynamicPixelDisplay<SinglePixel>> = DisplayDriver::new(
+    ///     DynamicPixelDisplay::<SinglePixel>::build_from_data(
+    ///         6,
+    ///         6,
+    ///         &vec![
+    ///             true, true, true, true,  true, true, // 0
+    ///             true, true, true, true,  true, true, // 1
+    ///             true, true, true, false, true, true, //-2-
+    ///             true, true, true, true,  true, true, // 3
+    ///             true, true, true, true,  true, true, // 4
+    ///             true, true, true, true,  true, true, // 5
+    ///         ] //  0     1     2   --3--    4     5
+    ///     ).expect("Could not construct display.")
+    /// );
+    /// // Replace with actual error handling
+    ///
+    /// let pixel = disp.get_pixel(3, 2);
+    ///
+    /// assert_eq!(pixel, Ok(false));
+    ///
+    /// let pixel = disp.get_pixel(5, 6);
+    ///
+    /// assert!(matches!(pixel, Err(_)));
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the pixel coordinates are out of bounds.
+    ///
+    /// # Panics
+    ///
+    /// If the index of a subpixel is out of bounds.
+    /// This should not happen and is subject to change in the future.
+    fn get_pixel(&self, x: usize, y: usize) -> Result<T::U, String>
+    where
+        [(); T::WIDTH * T::HEIGHT]:,
+    {
+        if x >= self.get_width() || y >= self.get_height() {
+            return Err(format!(
+                "Pixel coordinates out of bounds. Got x = {x}, y = {y}."
+            ));
+        }
+
+        let block_x: usize = x / T::WIDTH;
+        let block_y: usize = y / T::HEIGHT;
+        let offset_x: usize = x % T::WIDTH;
+        let offset_y: usize = y % T::HEIGHT;
+
+        let pixel = &self.get_data()
+            [block_x + block_y * self.get_width_characters()];
+
+        Ok(pixel
+            .get_subpixel(offset_x, offset_y)
+            .expect("Offset should be 0 or 1."))
+    }
+
+    /// Set a pixel at the specified coordinate with a given value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the pixel coordinates are out of bounds.
+    ///
+    /// # Panics
+    ///
+    /// If the index of a subpixel is out of bounds.
+    /// This should not happen and is subject to change in the future.
+    fn set_pixel(
+        &mut self,
+        x: usize,
+        y: usize,
+        value: T::U,
+    ) -> Result<(), String>
+    where
+        [(); T::WIDTH * T::HEIGHT]:,
+    {
+        if x >= self.get_width() || y >= self.get_height() {
+            return Err(format!(
+                "Pixel coordinates out of bounds. Got x = {x}, y = {y}."
+            ));
+        }
+
+        let block_x: usize = x / T::WIDTH;
+        let block_y: usize = y / T::HEIGHT;
+        let offset_x: usize = x % T::WIDTH;
+        let offset_y: usize = y % T::HEIGHT;
+
+        let width_characters = self.get_width_characters();
+        let pixel =
+            &mut self.get_data_mut()[block_x + block_y * width_characters];
+        pixel
+            .set_subpixel(offset_x, offset_y, value)
+            .expect("Offset should be 0 or 1.");
+
+        Ok(())
+    }
+
+    fn draw_line(
+        &mut self,
+        x1: f32,
+        y1: f32,
+        x2: f32,
+        y2: f32,
+        value: T::U,
+    ) where
+        [(); T::WIDTH * T::HEIGHT]:,
+    {
+        let dx = x2 - x1;
+        let dy = y2 - y1;
+
+        let steps: f32 = dx.abs().max(dy.abs());
+        let x_inc = dx / steps;
+        let y_inc = dy / steps;
+
+        let mut x = x1;
+        let mut y = y1;
+
+        for _ in 0..=steps.round() as usize {
+            if x >= 0. && y >= 0. {
+                let _ = self.set_pixel(
+                    x.round() as usize,
+                    y.round() as usize,
+                    value,
+                );
+            }
+            x += x_inc;
+            y += y_inc;
+        }
+    }
 }

--- a/src/display/console_display.rs
+++ b/src/display/console_display.rs
@@ -68,7 +68,7 @@ pub trait ConsoleDisplay<T: Pixel>: DynamicWidget {
     #[must_use]
     fn get_data(&self) -> &[T];
 
-    fn get_data_mut(&mut self) -> &mut [T];
+    fn get_data_mut(&mut self) -> &mut Box<[T]>;
 
     /// Returns a bool representing the state of the pixel at the specified coordinate.
     ///

--- a/src/display/console_display.rs
+++ b/src/display/console_display.rs
@@ -1,9 +1,9 @@
 use crate::{
-    pixel::monochrome_pixel::MultiPixel,
+    pixel::Pixel,
     widget::DynamicWidget,
 };
 
-pub trait ConsoleDisplay<T: MultiPixel>: DynamicWidget {
+pub trait ConsoleDisplay<T: Pixel>: DynamicWidget {
     /// Returns the width of the display in a display specific, individually addressable unit (e.g. pixels, characters).
     fn get_width(&self) -> usize;
     /// Returns the height of the display in a display specific, individually addressable unit (e.g. pixels, characters).

--- a/src/display/display_driver.rs
+++ b/src/display/display_driver.rs
@@ -72,7 +72,7 @@ impl<T: DynamicWidget> DisplayDriver<T> {
         let mut stdout = io::stdout();
 
         write!(stdout, "\x1B[H")?;
-        write!(stdout, "{}", self.get_widget().to_string())?;
+        write!(stdout, "{}", self.get_widget())?;
 
         Ok(())
     }

--- a/src/display/display_driver.rs
+++ b/src/display/display_driver.rs
@@ -63,29 +63,37 @@ impl<T: DynamicWidget> DisplayDriver<T> {
         }
     }
 
-    pub fn print_display(&self) -> Result<(), String> {
+    /// Prints the display to the terminal.
+    ///
+    /// # Errors
+    ///
+    /// May return an error if write! is unsuccessful.
+    pub fn print_display(&self) -> Result<(), io::Error> {
         let mut stdout = io::stdout();
 
-        if let Err(e) = write!(stdout, "\x1B[H") {
-            return Err(e.to_string());
-        }
-        if let Err(e) = write!(stdout, "{}", self.get_widget().to_string())
-        {
-            return Err(e.to_string());
-        }
+        write!(stdout, "\x1B[H")?;
+        write!(stdout, "{}", self.get_widget().to_string())?;
 
         Ok(())
     }
 
-    pub fn initialize(&self) -> Result<(), String> {
+    /// Initializes the display driver.
+    /// This function enables terminal raw mode and
+    /// sets the dimensions of the screen to match the widget's dimensions.
+    /// It enters alternate screen mode,
+    /// hides the cursor and disables line wrapping.
+    ///
+    /// # Error
+    ///
+    /// Returns an error when any on the actions above fail.
+    /// Note that resizing the terminal does not fail, if the terminal does not support it.
+    pub fn initialize(&self) -> Result<(), io::Error> {
         let mut stdout = io::stdout();
 
         // enables terminal raw mode
-        if let Err(e) = terminal::enable_raw_mode() {
-            return Err(e.to_string());
-        }
+        terminal::enable_raw_mode()?;
 
-        if let Err(e) = crossterm::execute!(
+        crossterm::execute!(
             stdout,
             terminal::EnterAlternateScreen, // use alternate screen
             terminal::SetSize(
@@ -95,9 +103,7 @@ impl<T: DynamicWidget> DisplayDriver<T> {
             terminal::DisableLineWrap,      // disable line wrapping
             terminal::Clear(terminal::ClearType::All), // clear screen
             cursor::Hide,                   // hide cursor blinking
-        ) {
-            return Err(e.to_string());
-        }
+        )?;
 
         Ok(())
     }
@@ -125,14 +131,25 @@ impl<T: DynamicWidget> DisplayDriver<T> {
         self.on_update = Some(Box::new(on_update));
     }
 
-    pub fn set_target_frame_time(&mut self, frame_time: Duration) {
-        self.target_frame_time = frame_time
+    pub const fn set_target_frame_time(&mut self, frame_time: Duration) {
+        self.target_frame_time = frame_time;
     }
 
     pub fn set_target_frame_rate(&mut self, frame_rate: f32) {
-        self.target_frame_time = Duration::from_secs_f32(1. / frame_rate)
+        self.target_frame_time = Duration::from_secs_f32(1. / frame_rate);
     }
 
+    /// This function encapsulates the update loop of the display.
+    /// As such it may or may not return depending on the update callback set with
+    /// `set_on_update`.
+    /// This function prints the display.
+    /// Queries user input and exits on Ctrl-C.
+    /// Forwards keystrokes to the provided callback and invokes it.
+    /// Sleeps so the target frame rate is not exceeded.
+    ///
+    /// # Panics
+    ///
+    /// This function panics when the display could not be printed.
     pub fn update(&mut self) {
         loop {
             let start = Instant::now();

--- a/src/display/pixel_display.rs
+++ b/src/display/pixel_display.rs
@@ -285,7 +285,8 @@ impl<T: MultiPixel, const WIDTH: usize, const HEIGHT: usize>
     ///
     /// If the index of a subpixel is out of bounds.
     /// This should not happen and is subject to change in the future.
-    #[must_use] pub fn get_pixel_static<const X: usize, const Y: usize>(&self) -> T::U
+    #[must_use]
+    pub fn get_pixel_static<const X: usize, const Y: usize>(&self) -> T::U
     where
         constraint!(X <= WIDTH):,
         constraint!(Y <= HEIGHT):,

--- a/src/display/pixel_display.rs
+++ b/src/display/pixel_display.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 pub struct DynamicPixelDisplay<T: MultiPixel> {
-    data: Vec<T>,
+    data: Box<[T]>,
     width: usize,
     height: usize,
 }
@@ -91,7 +91,7 @@ impl<T: MultiPixel> DynamicPixelDisplay<T> {
         Ok(Self {
             width,
             height,
-            data: multi_pixels,
+            data: multi_pixels.into_boxed_slice(),
         })
     }
 }
@@ -109,7 +109,7 @@ impl<T: MultiPixel> ConsoleDisplay<T> for DynamicPixelDisplay<T> {
         &self.data
     }
 
-    fn get_data_mut(&mut self) -> &mut [T] {
+    fn get_data_mut(&mut self) -> &mut Box<[T]> {
         &mut self.data
     }
 }
@@ -149,7 +149,7 @@ pub struct StaticPixelDisplay<
     const WIDTH: usize,
     const HEIGHT: usize,
 > {
-    data: Vec<T>,
+    data: Box<[T]>,
 }
 
 impl<T: MultiPixel, const WIDTH: usize, const HEIGHT: usize>
@@ -194,7 +194,9 @@ impl<T: MultiPixel, const WIDTH: usize, const HEIGHT: usize>
             }
         }
 
-        Self { data: multi_pixels }
+        Self {
+            data: multi_pixels.into_boxed_slice(),
+        }
     }
 
     // TODO: Add proper double buffering.
@@ -283,7 +285,7 @@ impl<T: MultiPixel, const WIDTH: usize, const HEIGHT: usize>
     ///
     /// If the index of a subpixel is out of bounds.
     /// This should not happen and is subject to change in the future.
-    pub fn get_pixel_static<const X: usize, const Y: usize>(&self) -> T::U
+    #[must_use] pub fn get_pixel_static<const X: usize, const Y: usize>(&self) -> T::U
     where
         constraint!(X <= WIDTH):,
         constraint!(Y <= HEIGHT):,
@@ -340,7 +342,7 @@ impl<T: MultiPixel, const WIDTH: usize, const HEIGHT: usize>
         &self.data
     }
 
-    fn get_data_mut(&mut self) -> &mut [T] {
+    fn get_data_mut(&mut self) -> &mut Box<[T]> {
         &mut self.data
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -25,8 +25,8 @@ macro_rules! impl_new {
 }
 
 #[macro_export]
-macro_rules! eq {
-    ($a:expr, $b:expr) => {
-        [(); 0 - ($a ^ $b)]
-    };
+macro_rules! constraint {
+    {$x:expr} => {
+        [(); 0 - !$x as usize]
+    }
 }

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -1,3 +1,62 @@
+use std::fmt::Display;
+
 pub mod character_pixel;
 pub mod color_pixel;
 pub mod monochrome_pixel;
+
+pub trait Pixel: Display
+where
+    Self: Sized,
+{
+    type U: Copy;
+
+    /// The width of the block of pixels.
+    const WIDTH: usize;
+    /// The height of the block of pixels.
+    const HEIGHT: usize;
+
+    fn get_pixels(&self) -> &[Self::U; Self::WIDTH * Self::HEIGHT];
+
+    fn get_pixels_mut(
+        &mut self,
+    ) -> &mut [Self::U; Self::WIDTH * Self::HEIGHT];
+
+    /// Returns the value of the block at the specified coordinates.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error, if the coordinates are out of bounds.
+    fn get_subpixel(&self, x: usize, y: usize) -> Result<Self::U, String>
+    where
+        [(); Self::WIDTH * Self::HEIGHT]:,
+    {
+        self.get_pixels().get(x + y * Self::WIDTH).map_or_else(
+            || Err("Coordinates out of range.".to_string()),
+            |subpixel| Ok(*subpixel),
+        )
+    }
+
+    /// Returns the value of the block at the specified coordinates.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error, if the coordinates are out of bounds.
+    fn set_subpixel(
+        &mut self,
+        x: usize,
+        y: usize,
+        value: Self::U,
+    ) -> Result<(), String>
+    where
+        [(); Self::WIDTH * Self::HEIGHT]:,
+    {
+        let index = x + y * Self::WIDTH;
+        if index < self.get_pixels().len() {
+            self.get_pixels_mut()[index] = value;
+            Ok(())
+        }
+        else {
+            Err("Coordinates out of range.".to_string())
+        }
+    }
+}

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -4,7 +4,7 @@ pub mod character_pixel;
 pub mod color_pixel;
 pub mod monochrome_pixel;
 
-pub trait Pixel: Display
+pub trait Pixel: Display + Copy
 where
     Self: Sized,
 {

--- a/src/pixel/character_pixel.rs
+++ b/src/pixel/character_pixel.rs
@@ -15,6 +15,11 @@ pub struct CharacterPixel {
 }
 
 impl CharacterPixel {
+    /// Constructs a character pixel from a char, a foreground and a background color.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the character is a control character.
     pub fn build(
         character: char,
         foreground: Color,

--- a/src/pixel/character_pixel.rs
+++ b/src/pixel/character_pixel.rs
@@ -6,7 +6,7 @@ use std::fmt::{
 use super::color_pixel::Color;
 use unicode_width::UnicodeWidthChar;
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct CharacterPixel {
     character: char,
     foreground: Color,

--- a/src/pixel/character_pixel.rs
+++ b/src/pixel/character_pixel.rs
@@ -68,7 +68,8 @@ impl CharacterPixel {
         })
     }
 
-    #[must_use] pub const fn make_copy(&self) -> Self {
+    #[must_use]
+    pub const fn make_copy(&self) -> Self {
         let mut clone = *self;
         clone.set_copy(true);
         clone

--- a/src/pixel/character_pixel.rs
+++ b/src/pixel/character_pixel.rs
@@ -68,7 +68,7 @@ impl CharacterPixel {
         })
     }
 
-    pub fn make_copy(&self) -> Self {
+    #[must_use] pub const fn make_copy(&self) -> Self {
         let mut clone = *self;
         clone.set_copy(true);
         clone

--- a/src/pixel/character_pixel.rs
+++ b/src/pixel/character_pixel.rs
@@ -3,15 +3,41 @@ use std::fmt::{
     Display,
 };
 
+use crate::pixel::Pixel;
+
 use super::color_pixel::Color;
 use unicode_width::UnicodeWidthChar;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub struct CharacterPixel {
+    data: [CharacterPixelData; 1],
+}
+
+#[derive(Clone, Copy, Default)]
+pub struct CharacterPixelData {
     character: char,
     foreground: Color,
     background: Color,
+    copy: bool,
     width: usize,
+}
+
+impl Pixel for CharacterPixel {
+    type U = CharacterPixelData;
+
+    const WIDTH: usize = 1;
+
+    const HEIGHT: usize = 1;
+
+    fn get_pixels(&self) -> &[Self::U; Self::WIDTH * Self::HEIGHT] {
+        &self.data
+    }
+
+    fn get_pixels_mut(
+        &mut self,
+    ) -> &mut [Self::U; Self::WIDTH * Self::HEIGHT] {
+        &mut self.data
+    }
 }
 
 impl CharacterPixel {
@@ -26,38 +52,55 @@ impl CharacterPixel {
         background: Color,
     ) -> Result<Self, String> {
         Ok(Self {
-            character,
-            foreground,
-            background,
-            width: match UnicodeWidthChar::width(character) {
-                Some(val) => val,
-                None => {
-                    return Err(
-                        "Control characters are not allowed.".to_string()
-                    );
-                }
-            },
+            data: [CharacterPixelData {
+                character,
+                foreground,
+                background,
+                copy: false,
+                width: match UnicodeWidthChar::width(character) {
+                    Some(val) => val,
+                    None => {
+                        return Err("Control characters are not allowed."
+                            .to_string());
+                    }
+                },
+            }],
         })
+    }
+
+    pub fn make_copy(&self) -> Self {
+        let mut clone = *self;
+        clone.set_copy(true);
+        clone
     }
 
     #[must_use]
     pub const fn get_character(&self) -> char {
-        self.character
+        self.data[0].character
     }
 
     #[must_use]
     pub const fn get_foreground(&self) -> Color {
-        self.foreground
+        self.data[0].foreground
     }
 
     #[must_use]
     pub const fn get_background(&self) -> Color {
-        self.background
+        self.data[0].background
+    }
+
+    #[must_use]
+    pub const fn is_copy(&self) -> bool {
+        self.data[0].copy
+    }
+
+    const fn set_copy(&mut self, copy: bool) {
+        self.data[0].copy = copy;
     }
 
     #[must_use]
     pub const fn get_width(&self) -> usize {
-        self.width
+        self.data[0].width
     }
 }
 
@@ -67,9 +110,9 @@ impl Display for CharacterPixel {
             f,
             "{}",
             Color::color(
-                self.character.to_string().as_str(),
-                &self.foreground,
-                &self.background
+                self.get_character().to_string().as_str(),
+                &self.get_foreground(),
+                &self.get_background()
             )
         )
     }
@@ -77,6 +120,6 @@ impl Display for CharacterPixel {
 
 impl Debug for CharacterPixel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", &self.character)
+        write!(f, "{}", &self.get_character())
     }
 }

--- a/src/pixel/color_pixel.rs
+++ b/src/pixel/color_pixel.rs
@@ -47,6 +47,7 @@ impl Color {
     }
 }
 
+#[derive(Clone, Copy)]
 pub struct RGBColor {
     pub r: u8,
     pub g: u8,
@@ -124,14 +125,6 @@ impl RGBColor {
         )
     }
 }
-
-impl Clone for RGBColor {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl Copy for RGBColor {}
 
 /// Represents a singular pixel implementing the [`MultiPixel`] trait.
 pub struct ColorSinglePixel {

--- a/src/pixel/color_pixel.rs
+++ b/src/pixel/color_pixel.rs
@@ -2,16 +2,20 @@ use std::fmt::Display;
 
 use crate::{
     impl_getters,
-    pixel::monochrome_pixel::{
-        HexPixel,
-        MultiPixel,
-        OctPixel,
-        QuadPixel,
+    pixel::{
+        Pixel,
+        monochrome_pixel::{
+            HexPixel,
+            MultiPixel,
+            OctPixel,
+            QuadPixel,
+        },
     },
 };
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub enum Color {
+    #[default]
     Default,
     Color(RGBColor),
 }
@@ -131,18 +135,20 @@ pub struct ColorSinglePixel {
     pixels: [RGBColor; 1],
 }
 
-impl MultiPixel for ColorSinglePixel {
+impl Pixel for ColorSinglePixel {
     type U = RGBColor;
 
     const WIDTH: usize = 1;
 
     const HEIGHT: usize = 1;
 
+    impl_getters!(pixels: [Self::U; Self::WIDTH * Self::HEIGHT]);
+}
+
+impl MultiPixel for ColorSinglePixel {
     fn new(pixels: [Self::U; 1]) -> Self {
         Self { pixels }
     }
-
-    impl_getters!(pixels: [Self::U; Self::WIDTH * Self::HEIGHT]);
 }
 
 impl Display for ColorSinglePixel {
@@ -159,18 +165,20 @@ pub struct ColorDualPixel {
     pixels: [RGBColor; 2],
 }
 
-impl MultiPixel for ColorDualPixel {
+impl Pixel for ColorDualPixel {
     type U = RGBColor;
 
     const WIDTH: usize = 1;
 
     const HEIGHT: usize = 2;
 
+    impl_getters!(pixels: [Self::U; Self::WIDTH * Self::HEIGHT]);
+}
+
+impl MultiPixel for ColorDualPixel {
     fn new(pixels: [Self::U; 2]) -> Self {
         Self { pixels }
     }
-
-    impl_getters!(pixels: [Self::U; Self::WIDTH * Self::HEIGHT]);
 }
 
 impl Display for ColorDualPixel {
@@ -187,18 +195,20 @@ pub struct ColorQuadPixel {
     pixels: [RGBColor; 4],
 }
 
-impl MultiPixel for ColorQuadPixel {
+impl Pixel for ColorQuadPixel {
     type U = RGBColor;
 
     const WIDTH: usize = 2;
 
     const HEIGHT: usize = 2;
 
+    impl_getters!(pixels: [Self::U; Self::WIDTH * Self::HEIGHT]);
+}
+
+impl MultiPixel for ColorQuadPixel {
     fn new(pixels: [Self::U; 4]) -> Self {
         Self { pixels }
     }
-
-    impl_getters!(pixels: [Self::U; Self::WIDTH * Self::HEIGHT]);
 }
 
 impl Display for ColorQuadPixel {
@@ -235,18 +245,20 @@ pub struct ColorHexPixel {
     pixels: [RGBColor; 6],
 }
 
-impl MultiPixel for ColorHexPixel {
+impl Pixel for ColorHexPixel {
     type U = RGBColor;
 
     const WIDTH: usize = 2;
 
     const HEIGHT: usize = 3;
 
+    impl_getters!(pixels: [Self::U; Self::WIDTH * Self::HEIGHT]);
+}
+
+impl MultiPixel for ColorHexPixel {
     fn new(pixels: [Self::U; 6]) -> Self {
         Self { pixels }
     }
-
-    impl_getters!(pixels: [Self::U; Self::WIDTH * Self::HEIGHT]);
 }
 
 impl Display for ColorHexPixel {
@@ -283,18 +295,20 @@ pub struct ColorOctPixel {
     pixels: [RGBColor; 8],
 }
 
-impl MultiPixel for ColorOctPixel {
+impl Pixel for ColorOctPixel {
     type U = RGBColor;
 
     const WIDTH: usize = 2;
 
     const HEIGHT: usize = 4;
 
+    impl_getters!(pixels: [Self::U; Self::WIDTH * Self::HEIGHT]);
+}
+
+impl MultiPixel for ColorOctPixel {
     fn new(pixels: [Self::U; 8]) -> Self {
         Self { pixels }
     }
-
-    impl_getters!(pixels: [Self::U; Self::WIDTH * Self::HEIGHT]);
 }
 
 impl Display for ColorOctPixel {

--- a/src/pixel/color_pixel.rs
+++ b/src/pixel/color_pixel.rs
@@ -131,6 +131,7 @@ impl RGBColor {
 }
 
 /// Represents a singular pixel implementing the [`MultiPixel`] trait.
+#[derive(Clone, Copy)]
 pub struct ColorSinglePixel {
     pixels: [RGBColor; 1],
 }
@@ -161,6 +162,7 @@ impl Display for ColorSinglePixel {
     }
 }
 
+#[derive(Clone, Copy)]
 pub struct ColorDualPixel {
     pixels: [RGBColor; 2],
 }
@@ -191,6 +193,7 @@ impl Display for ColorDualPixel {
     }
 }
 
+#[derive(Clone, Copy)]
 pub struct ColorQuadPixel {
     pixels: [RGBColor; 4],
 }
@@ -241,6 +244,7 @@ impl Display for ColorQuadPixel {
     }
 }
 
+#[derive(Clone, Copy)]
 pub struct ColorHexPixel {
     pixels: [RGBColor; 6],
 }
@@ -291,6 +295,7 @@ impl Display for ColorHexPixel {
     }
 }
 
+#[derive(Clone, Copy)]
 pub struct ColorOctPixel {
     pixels: [RGBColor; 8],
 }

--- a/src/pixel/monochrome_pixel.rs
+++ b/src/pixel/monochrome_pixel.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 
 use crate::{
+    constraint,
     impl_getters,
     impl_new,
 };
@@ -62,6 +63,17 @@ where
         )
     }
 
+    fn get_subpixel_static<const X: usize, const Y: usize>(
+        &self,
+    ) -> Self::U
+    where
+        [(); Self::WIDTH * Self::HEIGHT]:,
+        constraint!(X < Self::WIDTH):,
+        constraint!(Y < Self::HEIGHT):,
+    {
+        self.get_pixels()[X + Y * Self::WIDTH]
+    }
+
     /// Returns the value of the block at the specified coordinates.
     ///
     /// # Errors
@@ -84,6 +96,17 @@ where
         else {
             Err("Coordinates out of range.".to_string())
         }
+    }
+
+    fn set_subpixel_static<const X: usize, const Y: usize>(
+        &mut self,
+        value: Self::U,
+    ) where
+        [(); Self::WIDTH * Self::HEIGHT]:,
+        constraint!(X < Self::WIDTH):,
+        constraint!(Y < Self::HEIGHT):,
+    {
+        self.get_pixels_mut()[X + Y * Self::WIDTH] = value;
     }
 }
 

--- a/src/pixel/monochrome_pixel.rs
+++ b/src/pixel/monochrome_pixel.rs
@@ -100,6 +100,7 @@ where
 }
 
 /// Represents a singular pixel implementing the [`MultiPixel`] trait.
+#[derive(Clone, Copy)]
 pub struct SinglePixel {
     pixels: [bool; 1],
 }
@@ -161,6 +162,7 @@ impl Display for SinglePixel {
 }
 
 /// Specifies a block of pixels with dimensions 1 (width) by 2 (height).
+#[derive(Clone, Copy)]
 pub struct DualPixel {
     pixels: [bool; 2],
 }
@@ -239,7 +241,7 @@ impl Display for DualPixel {
 }
 
 /// Specifies a block of pixels with dimensions 2 (width) by 2 (height).
-#[derive(Debug)]
+#[derive(Clone, Copy)]
 pub struct QuadPixel {
     pixels: [bool; 4],
 }
@@ -313,6 +315,7 @@ impl MultiPixel for QuadPixel {
 }
 
 /// Specifies a block of pixels with dimensions 2 (width) by 3 (height).
+#[derive(Clone, Copy)]
 pub struct HexPixel {
     pixels: [bool; 6],
 }
@@ -389,6 +392,7 @@ impl Display for HexPixel {
 }
 
 /// Specifies a block of pixels with dimensions 2 (width) by 4 (height).
+#[derive(Clone, Copy)]
 pub struct OctPixel {
     pixels: [bool; 8],
 }
@@ -479,6 +483,7 @@ impl Display for OctPixel {
 }
 
 /// Specifies a block of pixels with dimensions 2 (width) by 4 (height) with braille points.
+#[derive(Clone, Copy)]
 pub struct BrailleOctPixel {
     pixels: [bool; 8],
 }

--- a/src/pixel/monochrome_pixel.rs
+++ b/src/pixel/monochrome_pixel.rs
@@ -26,6 +26,9 @@ where
     ) -> &mut [Self::U; Self::WIDTH * Self::HEIGHT];
 
     /// Builds a block of pixels from a slice of pixels.
+    ///
+    /// # Errors
+    ///
     /// Returns an error, if the number of pixels does not match the dimensions of the block.
     fn build(args: &[Self::U]) -> Result<Self, String>
     where
@@ -45,7 +48,10 @@ where
     }
 
     /// Returns the value of the block at the specified coordinates.
-    /// Returns an error, if the coordinates are out-of-bounds.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error, if the coordinates are out of bounds.
     fn get_subpixel(&self, x: usize, y: usize) -> Result<Self::U, String>
     where
         [(); Self::WIDTH * Self::HEIGHT]:,
@@ -56,6 +62,11 @@ where
         )
     }
 
+    /// Returns the value of the block at the specified coordinates.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error, if the coordinates are out of bounds.
     fn set_subpixel(
         &mut self,
         x: usize,

--- a/src/pixel/monochrome_pixel.rs
+++ b/src/pixel/monochrome_pixel.rs
@@ -1,5 +1,7 @@
 use std::fmt::Display;
 
+use crate::pixel::Pixel;
+
 use crate::{
     constraint,
     impl_getters,
@@ -7,24 +9,11 @@ use crate::{
 };
 
 /// Specifies a block of pixels with specified dimensions.
-pub trait MultiPixel: ToString
+pub trait MultiPixel: Pixel
 where
     Self: Sized,
 {
-    type U: Copy;
-
-    /// The width of the block of pixels.
-    const WIDTH: usize;
-    /// The height of the block of pixels.
-    const HEIGHT: usize;
-
     fn new(pixels: [Self::U; Self::WIDTH * Self::HEIGHT]) -> Self;
-
-    fn get_pixels(&self) -> &[Self::U; Self::WIDTH * Self::HEIGHT];
-
-    fn get_pixels_mut(
-        &mut self,
-    ) -> &mut [Self::U; Self::WIDTH * Self::HEIGHT];
 
     /// Builds a block of pixels from a slice of pixels.
     ///
@@ -151,16 +140,18 @@ impl SinglePixel {
     }
 }
 
-impl MultiPixel for SinglePixel {
+impl Pixel for SinglePixel {
     type U = bool;
 
     const WIDTH: usize = 1;
 
     const HEIGHT: usize = 1;
 
-    impl_new!(SinglePixel, pixels: [bool; 1]);
-
     impl_getters!(pixels: [bool; 1]);
+}
+
+impl MultiPixel for SinglePixel {
+    impl_new!(SinglePixel, pixels: [bool; 1]);
 }
 
 impl Display for SinglePixel {
@@ -227,16 +218,18 @@ impl DualPixel {
     }
 }
 
-impl MultiPixel for DualPixel {
+impl Pixel for DualPixel {
     type U = bool;
 
     const WIDTH: usize = 1;
 
     const HEIGHT: usize = 2;
 
-    impl_new!(DualPixel, pixels: [bool; 2]);
-
     impl_getters!(pixels: [bool; 2]);
+}
+
+impl MultiPixel for DualPixel {
+    impl_new!(DualPixel, pixels: [bool; 2]);
 }
 
 impl Display for DualPixel {
@@ -305,16 +298,18 @@ impl Display for QuadPixel {
     }
 }
 
-impl MultiPixel for QuadPixel {
+impl Pixel for QuadPixel {
     type U = bool;
 
     const WIDTH: usize = 2;
 
     const HEIGHT: usize = 2;
 
-    impl_new!(QuadPixel, pixels: [bool; 4]);
-
     impl_getters!(pixels: [bool; 4]);
+}
+
+impl MultiPixel for QuadPixel {
+    impl_new!(QuadPixel, pixels: [bool; 4]);
 }
 
 /// Specifies a block of pixels with dimensions 2 (width) by 3 (height).
@@ -373,16 +368,18 @@ impl HexPixel {
     }
 }
 
-impl MultiPixel for HexPixel {
+impl Pixel for HexPixel {
     type U = bool;
 
     const WIDTH: usize = 2;
 
     const HEIGHT: usize = 3;
 
-    impl_new!(HexPixel, pixels: [bool; 6]);
-
     impl_getters!(pixels: [bool; 6]);
+}
+
+impl MultiPixel for HexPixel {
+    impl_new!(HexPixel, pixels: [bool; 6]);
 }
 
 impl Display for HexPixel {
@@ -461,16 +458,18 @@ impl OctPixel {
     }
 }
 
-impl MultiPixel for OctPixel {
+impl Pixel for OctPixel {
     type U = bool;
 
     const WIDTH: usize = 2;
 
     const HEIGHT: usize = 4;
 
-    impl_new!(OctPixel, pixels: [bool; 8]);
-
     impl_getters!(pixels: [bool; 8]);
+}
+
+impl MultiPixel for OctPixel {
+    impl_new!(OctPixel, pixels: [bool; 8]);
 }
 
 impl Display for OctPixel {
@@ -546,16 +545,18 @@ impl BrailleOctPixel {
     }
 }
 
-impl MultiPixel for BrailleOctPixel {
+impl Pixel for BrailleOctPixel {
     type U = bool;
 
     const WIDTH: usize = 2;
 
     const HEIGHT: usize = 4;
 
-    impl_new!(BrailleOctPixel, pixels: [bool; 8]);
-
     impl_getters!(pixels: [bool; 8]);
+}
+
+impl MultiPixel for BrailleOctPixel {
+    impl_new!(BrailleOctPixel, pixels: [bool; 8]);
 }
 
 impl Display for BrailleOctPixel {

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 pub mod single_widget;
 pub mod two_widget;
 
@@ -8,7 +10,7 @@ pub trait StaticWidget: DynamicWidget {
     const HEIGHT_CHARACTERS: usize;
 }
 
-pub trait DynamicWidget: ToString {
+pub trait DynamicWidget: Display {
     /// Returns the width of the display in characters.
     fn get_width_characters(&self) -> usize;
     /// Returns the height of the display in characters.

--- a/src/widget/single_widget.rs
+++ b/src/widget/single_widget.rs
@@ -65,6 +65,10 @@ impl<S: MultiPixel, const WIDTH: usize, const HEIGHT: usize>
     /// Gets the pixel at the _uv_ coordinate (x, y).
     /// Using coordinates outside the uv mapping is considered
     /// undefined behaviour at the moment and is subject to change.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the pixel coordinates calculated by the UV mapping are out of bounds.
     pub fn get_pixel(&self, x: f32, y: f32) -> Result<S::U, String>
     where
         [(); S::WIDTH * S::HEIGHT]:,
@@ -88,7 +92,10 @@ impl<S: MultiPixel, const WIDTH: usize, const HEIGHT: usize>
     }
 
     /// Sets the pixel at the _uv_ coordinate (x, y).
-    /// Using coordinates outside the uv mapping sets no pixel.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the coordinates are outside the uv mapping.
     pub fn set_pixel(
         &mut self,
         x: f32,
@@ -253,16 +260,14 @@ impl<S: MultiPixel, const WIDTH: usize, const HEIGHT: usize>
     ///
     /// use console_display::{
     ///     widget::single_widget::UvWidget,
-    ///     console_display::PixelDisplay,
+    ///     pixel_display::StaticPixelDisplay,
     ///     pixel::monochrome_pixel::SinglePixel,
     /// };
     ///
     /// let mut widget = UvWidget::new(
-    ///     PixelDisplay::<SinglePixel>::build(
-    ///         5,
-    ///         1,
+    ///     StaticPixelDisplay::<SinglePixel, 5, 1>::new(
     ///         false
-    ///     ).expect("Could not construct display.")
+    ///     )
     /// );
     ///
     /// widget.set_uv_x_min(-1.);
@@ -287,16 +292,14 @@ impl<S: MultiPixel, const WIDTH: usize, const HEIGHT: usize>
     ///
     /// use console_display::{
     ///     widget::single_widget::UvWidget,
-    ///     console_display::PixelDisplay,
+    ///     pixel_display::StaticPixelDisplay,
     ///     pixel::monochrome_pixel::SinglePixel,
     /// };
     ///
     /// let mut widget = UvWidget::new(
-    ///     PixelDisplay::<SinglePixel>::build(
-    ///         1,
-    ///         5,
+    ///     StaticPixelDisplay::<SinglePixel, 1, 5>::new(
     ///         false
-    ///     ).expect("Could not construct display.")
+    ///     )
     /// );
     ///
     /// widget.set_uv_y_min(-1.);
@@ -369,19 +372,22 @@ mod tests {
 
     #[test]
     fn test_texture_to_uv() {
-        let uv = UvWidget::<StaticPixelDisplay<SinglePixel, 1, 1>>::texture_to_uv(
+        let expected = 0.0005;
+        let actual = UvWidget::<StaticPixelDisplay<SinglePixel, 1, 1>>::texture_to_uv(
             500, 1000, -0.5, 0.5,
         );
-        assert_eq!((uv * 10000.).round() / 10000., 0.0005);
+        let error = expected * 0.0001;
+        assert!((actual - 0.0005).abs() < error);
     }
 
     #[test]
     fn test_uv_to_texture() {
-        let texture_coordinate = UvWidget::<
+        let expected = 1500;
+        let actual = UvWidget::<
             StaticPixelDisplay<SinglePixel, 1, 1>,
         >::uv_to_texture(
             0.5, -1.0, 1.0, 2000
         );
-        assert_eq!(texture_coordinate, 1500);
+        assert_eq!(actual, expected);
     }
 }

--- a/src/widget/single_widget.rs
+++ b/src/widget/single_widget.rs
@@ -1,4 +1,10 @@
-use std::fmt::Display;
+use std::{
+    fmt::Display,
+    ops::{
+        Deref,
+        DerefMut,
+    },
+};
 
 use crate::{
     console_display::ConsoleDisplay,
@@ -9,7 +15,9 @@ use crate::{
 
 use super::StaticWidget;
 
-pub trait SingleWidget<T: DynamicWidget>: DynamicWidget {
+pub trait SingleWidget<T: DynamicWidget>:
+    DynamicWidget + Deref + DerefMut
+{
     fn get_child(&self) -> &T;
     fn get_child_mut(&mut self) -> &mut T;
 }
@@ -333,6 +341,20 @@ impl<T: ConsoleDisplay + StaticWidget> SingleWidget<T> for UvWidget<T> {
 impl<T: ConsoleDisplay + StaticWidget> Display for UvWidget<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.get_child().to_string())
+    }
+}
+
+impl<T: ConsoleDisplay> Deref for UvWidget<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.child
+    }
+}
+
+impl<T: ConsoleDisplay> DerefMut for UvWidget<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.child
     }
 }
 

--- a/src/widget/two_widget.rs
+++ b/src/widget/two_widget.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crate::{
-    eq,
+    constraint,
     widget::DynamicWidget,
 };
 
@@ -28,8 +28,8 @@ pub struct OverlayWidget<S: DynamicWidget, T: DynamicWidget> {
 impl<S: StaticWidget, T: StaticWidget> OverlayWidget<S, T> {
     pub const fn new(child1: S, child2: T, child1_on_top: bool) -> Self
     where
-        eq!(S::WIDTH_CHARACTERS, T::WIDTH_CHARACTERS):,
-        eq!(S::HEIGHT_CHARACTERS, T::HEIGHT_CHARACTERS):,
+        constraint!(S::WIDTH_CHARACTERS == T::WIDTH_CHARACTERS):,
+        constraint!(S::HEIGHT_CHARACTERS == T::HEIGHT_CHARACTERS):,
     {
         Self {
             child1_on_top,
@@ -113,10 +113,10 @@ impl<S: DynamicWidget, T: DynamicWidget> TwoWidget<S, T>
 impl<S: DynamicWidget, T: DynamicWidget> Display for OverlayWidget<S, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.child1_on_top {
-            write!(f, "{}", self.children.0.to_string())
+            write!(f, "{}", self.children.0)
         }
         else {
-            write!(f, "{}", self.children.1.to_string())
+            write!(f, "{}", self.children.1)
         }
     }
 }
@@ -164,7 +164,7 @@ impl<S: DynamicWidget, T: DynamicWidget> HorizontalTilingWidget<S, T> {
 impl<S: StaticWidget, T: StaticWidget> HorizontalTilingWidget<S, T> {
     pub const fn new(child1: S, child2: T) -> Self
     where
-        eq!(S::HEIGHT_CHARACTERS, T::HEIGHT_CHARACTERS):,
+        constraint!(S::HEIGHT_CHARACTERS == T::HEIGHT_CHARACTERS):,
     {
         Self {
             children: (child1, child2),
@@ -268,7 +268,7 @@ impl<S: DynamicWidget, T: DynamicWidget> VerticalTilingWidget<S, T> {
 impl<S: StaticWidget, T: StaticWidget> VerticalTilingWidget<S, T> {
     pub const fn new(child1: S, child2: T) -> Self
     where
-        eq!(S::WIDTH_CHARACTERS, T::WIDTH_CHARACTERS):,
+        constraint!(S::WIDTH_CHARACTERS == T::WIDTH_CHARACTERS):,
     {
         Self {
             children: (child1, child2),
@@ -314,12 +314,7 @@ impl<S: DynamicWidget, T: DynamicWidget> Display
     for VerticalTilingWidget<S, T>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}\n{}",
-            self.children.0.to_string(),
-            self.children.1.to_string()
-        )
+        write!(f, "{}\n{}", self.children.0, self.children.1)
     }
 }
 

--- a/src/widget/two_widget.rs
+++ b/src/widget/two_widget.rs
@@ -1,4 +1,10 @@
-use std::fmt::Display;
+use std::{
+    fmt::Display,
+    ops::{
+        Deref,
+        DerefMut,
+    },
+};
 
 use crate::{
     eq,
@@ -8,7 +14,7 @@ use crate::{
 use super::StaticWidget;
 
 pub trait TwoWidget<S: DynamicWidget, T: DynamicWidget>:
-    DynamicWidget
+    DynamicWidget + Deref + DerefMut
 {
     fn get_children(&self) -> (&S, &T);
     fn get_children_mut(&mut self) -> (&mut S, &mut T);
@@ -16,20 +22,18 @@ pub trait TwoWidget<S: DynamicWidget, T: DynamicWidget>:
 
 pub struct OverlayWidget<S: DynamicWidget, T: DynamicWidget> {
     child1_on_top: bool,
-    child1: S,
-    child2: T,
+    children: (S, T),
 }
 
 impl<S: StaticWidget, T: StaticWidget> OverlayWidget<S, T> {
-    pub fn new(child1: S, child2: T, child1_on_top: bool) -> Self
+    pub const fn new(child1: S, child2: T, child1_on_top: bool) -> Self
     where
         eq!(S::WIDTH_CHARACTERS, T::WIDTH_CHARACTERS):,
         eq!(S::HEIGHT_CHARACTERS, T::HEIGHT_CHARACTERS):,
     {
         Self {
             child1_on_top,
-            child1,
-            child2,
+            children: (child1, child2),
         }
     }
 }
@@ -54,8 +58,7 @@ impl<S: DynamicWidget, T: DynamicWidget> OverlayWidget<S, T> {
         }
         Ok(Self {
             child1_on_top,
-            child1,
-            child2,
+            children: (child1, child2),
         })
     }
 
@@ -80,11 +83,11 @@ impl<S: DynamicWidget, T: DynamicWidget> DynamicWidget
     for OverlayWidget<S, T>
 {
     fn get_width_characters(&self) -> usize {
-        self.child1.get_width_characters()
+        self.children.0.get_width_characters()
     }
 
     fn get_height_characters(&self) -> usize {
-        self.child1.get_height_characters()
+        self.children.1.get_height_characters()
     }
 }
 
@@ -92,28 +95,41 @@ impl<S: DynamicWidget, T: DynamicWidget> TwoWidget<S, T>
     for OverlayWidget<S, T>
 {
     fn get_children(&self) -> (&S, &T) {
-        (&self.child1, &self.child2)
+        (&self.children.0, &self.children.1)
     }
 
     fn get_children_mut(&mut self) -> (&mut S, &mut T) {
-        (&mut self.child1, &mut self.child2)
+        (&mut self.children.0, &mut self.children.1)
     }
 }
 
 impl<S: DynamicWidget, T: DynamicWidget> Display for OverlayWidget<S, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.child1_on_top {
-            write!(f, "{}", self.child1.to_string())
+            write!(f, "{}", self.children.0.to_string())
         }
         else {
-            write!(f, "{}", self.child2.to_string())
+            write!(f, "{}", self.children.1.to_string())
         }
     }
 }
 
+impl<S: DynamicWidget, T: DynamicWidget> Deref for OverlayWidget<S, T> {
+    type Target = (S, T);
+
+    fn deref(&self) -> &Self::Target {
+        &self.children
+    }
+}
+
+impl<S: DynamicWidget, T: DynamicWidget> DerefMut for OverlayWidget<S, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.children
+    }
+}
+
 pub struct HorizontalTilingWidget<S: DynamicWidget, T: DynamicWidget> {
-    child1: S,
-    child2: T,
+    children: (S, T),
 }
 
 impl<S: DynamicWidget, T: DynamicWidget> HorizontalTilingWidget<S, T> {
@@ -126,16 +142,20 @@ impl<S: DynamicWidget, T: DynamicWidget> HorizontalTilingWidget<S, T> {
                 child2.get_height_characters()
             ));
         }
-        Ok(Self { child1, child2 })
+        Ok(Self {
+            children: (child1, child2),
+        })
     }
 }
 
 impl<S: StaticWidget, T: StaticWidget> HorizontalTilingWidget<S, T> {
-    pub fn new(child1: S, child2: T) -> Self
+    pub const fn new(child1: S, child2: T) -> Self
     where
         eq!(S::HEIGHT_CHARACTERS, T::HEIGHT_CHARACTERS):,
     {
-        Self { child1, child2 }
+        Self {
+            children: (child1, child2),
+        }
     }
 }
 
@@ -152,12 +172,12 @@ impl<S: DynamicWidget, T: DynamicWidget> DynamicWidget
     for HorizontalTilingWidget<S, T>
 {
     fn get_width_characters(&self) -> usize {
-        self.child1.get_width_characters() +
-            self.child2.get_width_characters()
+        self.children.0.get_width_characters() +
+            self.children.1.get_width_characters()
     }
 
     fn get_height_characters(&self) -> usize {
-        self.child1.get_height_characters()
+        self.children.0.get_height_characters()
     }
 }
 
@@ -165,11 +185,11 @@ impl<S: DynamicWidget, T: DynamicWidget> TwoWidget<S, T>
     for HorizontalTilingWidget<S, T>
 {
     fn get_children(&self) -> (&S, &T) {
-        (&self.child1, &self.child2)
+        (&self.children.0, &self.children.1)
     }
 
     fn get_children_mut(&mut self) -> (&mut S, &mut T) {
-        (&mut self.child1, &mut self.child2)
+        (&mut self.children.0, &mut self.children.1)
     }
 }
 
@@ -177,8 +197,8 @@ impl<S: DynamicWidget, T: DynamicWidget> Display
     for HorizontalTilingWidget<S, T>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let str_repr1 = self.child1.to_string();
-        let str_repr2 = self.child2.to_string();
+        let str_repr1 = self.children.0.to_string();
+        let str_repr2 = self.children.1.to_string();
         let lines = Iterator::zip(str_repr1.lines(), str_repr2.lines());
         let mut str_repr = String::new();
         for line_pair in lines {
@@ -189,9 +209,26 @@ impl<S: DynamicWidget, T: DynamicWidget> Display
     }
 }
 
+impl<S: DynamicWidget, T: DynamicWidget> Deref
+    for HorizontalTilingWidget<S, T>
+{
+    type Target = (S, T);
+
+    fn deref(&self) -> &Self::Target {
+        &self.children
+    }
+}
+
+impl<S: DynamicWidget, T: DynamicWidget> DerefMut
+    for HorizontalTilingWidget<S, T>
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.children
+    }
+}
+
 pub struct VerticalTilingWidget<S: DynamicWidget, T: DynamicWidget> {
-    child1: S,
-    child2: T,
+    children: (S, T),
 }
 
 impl<S: DynamicWidget, T: DynamicWidget> VerticalTilingWidget<S, T> {
@@ -203,16 +240,20 @@ impl<S: DynamicWidget, T: DynamicWidget> VerticalTilingWidget<S, T> {
                 child2.get_width_characters()
             ));
         }
-        Ok(Self { child1, child2 })
+        Ok(Self {
+            children: (child1, child2),
+        })
     }
 }
 
 impl<S: StaticWidget, T: StaticWidget> VerticalTilingWidget<S, T> {
-    pub fn new(child1: S, child2: T) -> Self
+    pub const fn new(child1: S, child2: T) -> Self
     where
         eq!(S::WIDTH_CHARACTERS, T::WIDTH_CHARACTERS):,
     {
-        Self { child1, child2 }
+        Self {
+            children: (child1, child2),
+        }
     }
 }
 
@@ -229,12 +270,12 @@ impl<S: DynamicWidget, T: DynamicWidget> DynamicWidget
     for VerticalTilingWidget<S, T>
 {
     fn get_width_characters(&self) -> usize {
-        self.child1.get_width_characters()
+        self.children.0.get_width_characters()
     }
 
     fn get_height_characters(&self) -> usize {
-        self.child1.get_height_characters() +
-            self.child2.get_height_characters()
+        self.children.0.get_height_characters() +
+            self.children.1.get_height_characters()
     }
 }
 
@@ -242,11 +283,11 @@ impl<S: DynamicWidget, T: DynamicWidget> TwoWidget<S, T>
     for VerticalTilingWidget<S, T>
 {
     fn get_children(&self) -> (&S, &T) {
-        (&self.child1, &self.child2)
+        (&self.children.0, &self.children.1)
     }
 
     fn get_children_mut(&mut self) -> (&mut S, &mut T) {
-        (&mut self.child1, &mut self.child2)
+        (&mut self.children.0, &mut self.children.1)
     }
 }
 
@@ -257,8 +298,26 @@ impl<S: DynamicWidget, T: DynamicWidget> Display
         write!(
             f,
             "{}\n{}",
-            self.child1.to_string(),
-            self.child2.to_string()
+            self.children.0.to_string(),
+            self.children.1.to_string()
         )
+    }
+}
+
+impl<S: DynamicWidget, T: DynamicWidget> Deref
+    for VerticalTilingWidget<S, T>
+{
+    type Target = (S, T);
+
+    fn deref(&self) -> &Self::Target {
+        &self.children
+    }
+}
+
+impl<S: DynamicWidget, T: DynamicWidget> DerefMut
+    for VerticalTilingWidget<S, T>
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.children
     }
 }

--- a/src/widget/two_widget.rs
+++ b/src/widget/two_widget.rs
@@ -314,7 +314,7 @@ impl<S: DynamicWidget, T: DynamicWidget> Display
     for VerticalTilingWidget<S, T>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}\n{}", self.children.0, self.children.1)
+        write!(f, "{}\r\n{}", self.children.0, self.children.1)
     }
 }
 

--- a/src/widget/two_widget.rs
+++ b/src/widget/two_widget.rs
@@ -39,6 +39,13 @@ impl<S: StaticWidget, T: StaticWidget> OverlayWidget<S, T> {
 }
 
 impl<S: DynamicWidget, T: DynamicWidget> OverlayWidget<S, T> {
+    /// Builds an overlay widget with two children.
+    /// The `child1_on_top` parameter determines whether the first child should be
+    /// on top or below the second child.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the dimensions of both children don't match.
     pub fn build(
         child1: S,
         child2: T,
@@ -133,6 +140,12 @@ pub struct HorizontalTilingWidget<S: DynamicWidget, T: DynamicWidget> {
 }
 
 impl<S: DynamicWidget, T: DynamicWidget> HorizontalTilingWidget<S, T> {
+    /// Builds horizontal tiling widget with two children.
+    /// `child1` will be displayed on the left, `child2` on the right.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the height of both children does not match.
     pub fn build(child1: S, child2: T) -> Result<Self, String> {
         if child1.get_height_characters() != child2.get_height_characters()
         {
@@ -232,10 +245,16 @@ pub struct VerticalTilingWidget<S: DynamicWidget, T: DynamicWidget> {
 }
 
 impl<S: DynamicWidget, T: DynamicWidget> VerticalTilingWidget<S, T> {
+    /// Builds vertical tiling widget with two children.
+    /// `child1` will be displayed on the top, `child2` on the bottom.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the width of both children does not match.
     pub fn build(child1: S, child2: T) -> Result<Self, String> {
         if child1.get_width_characters() != child2.get_width_characters() {
             return Err(format!(
-                "Height in characters of arguments does not match. {} and {}.",
+                "Width in characters of arguments does not match. {} and {}.",
                 child1.get_width_characters(),
                 child2.get_width_characters()
             ));


### PR DESCRIPTION
- Add double buffering widget
- Add frame time handling in display driver
- Make heavy use of deref to avoid repeated "get_child" calls
- Fix many issues with the character display
- Add game of life example using double buffering
- Refactor the snake example to use frame time management of the display driver
- Change the text example to use a double-wide character as background for demonstration purposes