### PR TITLE
Test/add unit tests

### DIFF
--- a/examples/snake.rs
+++ b/examples/snake.rs
@@ -229,7 +229,7 @@ type Display = DisplayDriver<
 
 fn construct_display() -> Display {
     DisplayDriver::new(VerticalTilingWidget::new(
-        CharacterDisplay::<_, 100, 1>::build(
+        CharacterDisplay::<_, 100, 1>::new(
             CharacterPixel::build(
                 ' ',
                 Color::Color(RGBColor { r: 0, g: 0, b: 0 }),
@@ -240,19 +240,17 @@ fn construct_display() -> Display {
                 }),
             )
             .unwrap(),
-        )
-        .unwrap(),
+        ),
         OverlayWidget::new(
             StaticPixelDisplay::<ColorDualPixel, 100, 42>::new(RGBColor {
                 r: 0,
                 b: 0,
                 g: 0,
             }),
-            CharacterDisplay::<CharacterPixel, 100, 21>::build(
+            CharacterDisplay::<CharacterPixel, 100, 21>::new(
                 CharacterPixel::build(' ', Color::Default, Color::Default)
                     .unwrap(),
-            )
-            .unwrap(),
+            ),
             true,
         ),
     ))

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -12,11 +12,10 @@ use console_display::{
 
 fn main() {
     let mut char_disp: CharacterDisplay<CharacterPixel, 40, 20> =
-        CharacterDisplay::build(
+        CharacterDisplay::new(
             CharacterPixel::build('あ', Color::Default, Color::Default)
                 .unwrap(),
-        )
-        .unwrap();
+        );
 
     let mut x = 0;
     let mut y = 0;

--- a/src/display/console_display.rs
+++ b/src/display/console_display.rs
@@ -9,7 +9,6 @@ pub trait ConsoleDisplay<T: Pixel>: DynamicWidget {
     /// Returns the height of the display in a display specific, individually addressable unit (e.g. pixels, characters).
     fn get_height(&self) -> usize;
 
-    // TODO: Add proper double buffering.
     /// Returns a vector containing all the pixels in the display.
     ///
     /// # Panics

--- a/src/display/pixel_display.rs
+++ b/src/display/pixel_display.rs
@@ -24,7 +24,7 @@ impl<T: MultiPixel> DynamicPixelDisplay<T> {
     ///
     /// This function panics if the data generated from the fill does not match the dimensions of the display.
     /// This should not happen and is subject to change in the future.
-    pub fn build(width: usize, height: usize, fill: T::U) -> Self
+    pub fn new(width: usize, height: usize, fill: T::U) -> Self
     where
         Self: Sized,
         [(); T::WIDTH * T::HEIGHT]:,
@@ -54,7 +54,7 @@ impl<T: MultiPixel> DynamicPixelDisplay<T> {
                 "Width and height must be multiples of multipixel dimensions. Got width = {width}, height = {height}."
             ));
         }
-        if data.len() / width / height != 1 {
+        if data.len() != width * height {
             return Err(format!(
                 "Data does not match specified dimensions. Expected length of {}, got {}.",
                 width * height,
@@ -198,7 +198,6 @@ impl<T: MultiPixel, const WIDTH: usize, const HEIGHT: usize>
         }
     }
 
-    // TODO: Add proper double buffering.
     /// Returns a vector containing all the pixels in the display.
     ///
     /// # Panics
@@ -385,5 +384,83 @@ impl<T: MultiPixel, const WIDTH: usize, const HEIGHT: usize> Display
         }
 
         write!(f, "{}", string_repr.trim_end_matches("\r\n"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::pixel::monochrome_pixel::SinglePixel;
+
+    use super::*;
+
+    mod dynamic_pixel_display {
+        use super::*;
+
+        #[test]
+        fn build_from_data_success() {
+            let dynamic_pixel_display =
+                DynamicPixelDisplay::<SinglePixel>::build_from_data(
+                    1,
+                    1,
+                    &[false],
+                );
+            assert!(dynamic_pixel_display.is_ok());
+        }
+
+        #[test]
+        fn build_from_data_failure_less() {
+            let dynamic_pixel_display =
+                DynamicPixelDisplay::<SinglePixel>::build_from_data(
+                    23,
+                    1,
+                    &[false; 22],
+                );
+            assert!(dynamic_pixel_display.is_err());
+        }
+
+        #[test]
+        fn build_from_data_failure_more() {
+            let dynamic_pixel_display =
+                DynamicPixelDisplay::<SinglePixel>::build_from_data(
+                    23,
+                    1,
+                    &[false; 24],
+                );
+            assert!(dynamic_pixel_display.is_err());
+        }
+
+        #[test]
+        fn get_pixel_success() {
+            let dynamic_pixel_display =
+                DynamicPixelDisplay::<SinglePixel>::new(2, 1, false);
+            let pixel = dynamic_pixel_display.get_pixel(1, 0);
+            assert!(pixel.is_ok());
+        }
+
+        #[test]
+        fn get_pixel_failure() {
+            let dynamic_pixel_display =
+                DynamicPixelDisplay::<SinglePixel>::new(2, 1, false);
+            let pixel = dynamic_pixel_display.get_pixel(0, 1);
+            assert!(pixel.is_err());
+        }
+
+        #[test]
+        fn set_pixel_success() {
+            let mut dynamic_pixel_display =
+                DynamicPixelDisplay::<SinglePixel>::new(2, 1, false);
+            let res = dynamic_pixel_display.set_pixel(1, 0, true);
+            let pixel = dynamic_pixel_display.get_pixel(1, 0);
+            assert!(res.is_ok());
+            assert_eq!(pixel, Ok(true));
+        }
+
+        #[test]
+        fn set_pixel_failure() {
+            let mut dynamic_pixel_display =
+                DynamicPixelDisplay::<SinglePixel>::new(2, 1, false);
+            let res = dynamic_pixel_display.set_pixel(0, 1, true);
+            assert!(res.is_err());
+        }
     }
 }

--- a/src/pixel/character_pixel.rs
+++ b/src/pixel/character_pixel.rs
@@ -8,12 +8,12 @@ use crate::pixel::Pixel;
 use super::color_pixel::Color;
 use unicode_width::UnicodeWidthChar;
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy)]
 pub struct CharacterPixel {
     data: [CharacterPixelData; 1],
 }
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy)]
 pub struct CharacterPixelData {
     character: char,
     foreground: Color,

--- a/src/widget/single_widget.rs
+++ b/src/widget/single_widget.rs
@@ -556,53 +556,66 @@ mod tests {
 
     use super::*;
 
-    #[test]
-    fn test_texture_to_uv() {
-        let expected = 0.0005;
-        let actual = UvWidget::<
-            StaticPixelDisplay<SinglePixel, 1, 1>,
-            SinglePixel,
-        >::texture_to_uv(500, 1000, -0.5, 0.5);
-        let error = expected * 0.0001;
-        assert!((actual - 0.0005).abs() < error);
+    mod uv_widget {
+        use super::*;
+
+        #[test]
+        fn texture_to_uv() {
+            let expected = 0.0005;
+            let actual = UvWidget::<
+                StaticPixelDisplay<SinglePixel, 1, 1>,
+                SinglePixel,
+            >::texture_to_uv(500, 1000, -0.5, 0.5);
+            let error = expected * 0.0001;
+            assert!((actual - 0.0005).abs() < error);
+        }
+
+        #[test]
+        fn uv_to_texture() {
+            let expected = 1500;
+            let actual = UvWidget::<
+                StaticPixelDisplay<SinglePixel, 1, 1>,
+                SinglePixel,
+            >::uv_to_texture(0.5, -1.0, 1.0, 2000);
+            assert_eq!(actual, expected);
+        }
     }
 
-    #[test]
-    fn test_uv_to_texture() {
-        let expected = 1500;
-        let actual = UvWidget::<
-            StaticPixelDisplay<SinglePixel, 1, 1>,
-            SinglePixel,
-        >::uv_to_texture(0.5, -1.0, 1.0, 2000);
-        assert_eq!(actual, expected);
-    }
+    mod double_buffer_widget {
+        use super::*;
 
-    #[test]
-    fn test_buffer_swap() {
-        let mut widget =
-            DoubleBufferWidget::new(
+        #[test]
+        fn buffer_swap() {
+            let mut widget =
+                DoubleBufferWidget::new(StaticPixelDisplay::<
+                    SinglePixel,
+                    1,
+                    1,
+                >::new(false));
+            widget.set_pixel_static::<0, 0>(true);
+            let buffer1 = widget.backbuffer.clone();
+            widget.swap_buffers();
+            let buffer2 = widget.backbuffer;
+            assert_ne!(
+                buffer1.borrow()[0].to_string(),
+                buffer2.borrow()[0].to_string()
+            )
+        }
+    }
+    mod padding_widget {
+        use super::*;
+
+        #[test]
+        fn dimensions() {
+            let widget = PaddingWidget::new(
                 StaticPixelDisplay::<SinglePixel, 1, 1>::new(false),
+                10,
+                20,
+                30,
+                40,
             );
-        widget.set_pixel_static::<0, 0>(true);
-        let buffer1 = widget.backbuffer.clone();
-        widget.swap_buffers();
-        let buffer2 = widget.backbuffer;
-        assert_ne!(
-            buffer1.borrow()[0].to_string(),
-            buffer2.borrow()[0].to_string()
-        )
-    }
-
-    #[test]
-    fn test_padding_dimensions() {
-        let widget = PaddingWidget::new(
-            StaticPixelDisplay::<SinglePixel, 1, 1>::new(false),
-            10,
-            20,
-            30,
-            40,
-        );
-        assert_eq!(widget.get_width_characters(), 31);
-        assert_eq!(widget.get_height_characters(), 71)
+            assert_eq!(widget.get_width_characters(), 31);
+            assert_eq!(widget.get_height_characters(), 71)
+        }
     }
 }

--- a/src/widget/single_widget.rs
+++ b/src/widget/single_widget.rs
@@ -576,4 +576,33 @@ mod tests {
         >::uv_to_texture(0.5, -1.0, 1.0, 2000);
         assert_eq!(actual, expected);
     }
+
+    #[test]
+    fn test_buffer_swap() {
+        let mut widget =
+            DoubleBufferWidget::new(
+                StaticPixelDisplay::<SinglePixel, 1, 1>::new(false),
+            );
+        widget.set_pixel_static::<0, 0>(true);
+        let buffer1 = widget.backbuffer.clone();
+        widget.swap_buffers();
+        let buffer2 = widget.backbuffer;
+        assert_ne!(
+            buffer1.borrow()[0].to_string(),
+            buffer2.borrow()[0].to_string()
+        )
+    }
+
+    #[test]
+    fn test_padding_dimensions() {
+        let widget = PaddingWidget::new(
+            StaticPixelDisplay::<SinglePixel, 1, 1>::new(false),
+            10,
+            20,
+            30,
+            40,
+        );
+        assert_eq!(widget.get_width_characters(), 31);
+        assert_eq!(widget.get_height_characters(), 71)
+    }
 }

--- a/src/widget/two_widget.rs
+++ b/src/widget/two_widget.rs
@@ -297,3 +297,100 @@ impl<S: DynamicWidget, T: DynamicWidget> DerefMut
         &mut self.children
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        pixel::monochrome_pixel::SinglePixel,
+        pixel_display::StaticPixelDisplay,
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_overlay_build_success() {
+        let overlay = OverlayWidget::build(
+            StaticPixelDisplay::<SinglePixel, 1, 1>::new(false),
+            StaticPixelDisplay::<SinglePixel, 1, 1>::new(true),
+            true,
+        );
+        assert!(overlay.is_ok());
+    }
+
+    #[test]
+    fn test_overlay_build_failure() {
+        let overlay = OverlayWidget::build(
+            StaticPixelDisplay::<SinglePixel, 1, 1>::new(false),
+            StaticPixelDisplay::<SinglePixel, 1, 2>::new(true),
+            true,
+        );
+        assert!(overlay.is_err());
+    }
+
+    #[test]
+    fn test_overlay_dimensions() {
+        let overlay = OverlayWidget::new(
+            StaticPixelDisplay::<SinglePixel, 37, 63>::new(false),
+            StaticPixelDisplay::<SinglePixel, 37, 63>::new(true),
+            true,
+        );
+        assert_eq!(overlay.get_width_characters(), 37);
+        assert_eq!(overlay.get_height_characters(), 63);
+    }
+
+    #[test]
+    fn test_horizontal_tiling_build_success() {
+        let overlay = HorizontalTilingWidget::build(
+            StaticPixelDisplay::<SinglePixel, 3, 10>::new(false),
+            StaticPixelDisplay::<SinglePixel, 2, 10>::new(true),
+        );
+        assert!(overlay.is_ok());
+    }
+
+    #[test]
+    fn test_horizontal_tiling_build_failure() {
+        let overlay = HorizontalTilingWidget::build(
+            StaticPixelDisplay::<SinglePixel, 10, 3>::new(false),
+            StaticPixelDisplay::<SinglePixel, 10, 2>::new(true),
+        );
+        assert!(overlay.is_err());
+    }
+
+    #[test]
+    fn test_horizontal_tiling_dimensions() {
+        let overlay = HorizontalTilingWidget::new(
+            StaticPixelDisplay::<SinglePixel, 37, 20>::new(false),
+            StaticPixelDisplay::<SinglePixel, 63, 20>::new(true),
+        );
+        assert_eq!(overlay.get_width_characters(), 100);
+        assert_eq!(overlay.get_height_characters(), 20);
+    }
+
+    #[test]
+    fn test_vertical_tiling_build_success() {
+        let overlay = VerticalTilingWidget::build(
+            StaticPixelDisplay::<SinglePixel, 20, 5>::new(false),
+            StaticPixelDisplay::<SinglePixel, 20, 4>::new(true),
+        );
+        assert!(overlay.is_ok());
+    }
+
+    #[test]
+    fn test_vertical_tiling_build_failure() {
+        let overlay = VerticalTilingWidget::build(
+            StaticPixelDisplay::<SinglePixel, 5, 20>::new(false),
+            StaticPixelDisplay::<SinglePixel, 4, 20>::new(true),
+        );
+        assert!(overlay.is_err());
+    }
+
+    #[test]
+    fn test_vertical_tiling_dimensions() {
+        let overlay = VerticalTilingWidget::new(
+            StaticPixelDisplay::<SinglePixel, 30, 45>::new(false),
+            StaticPixelDisplay::<SinglePixel, 30, 54>::new(true),
+        );
+        assert_eq!(overlay.get_width_characters(), 30);
+        assert_eq!(overlay.get_height_characters(), 99);
+    }
+}

--- a/src/widget/two_widget.rs
+++ b/src/widget/two_widget.rs
@@ -307,90 +307,102 @@ mod tests {
 
     use super::*;
 
-    #[test]
-    fn test_overlay_build_success() {
-        let overlay = OverlayWidget::build(
-            StaticPixelDisplay::<SinglePixel, 1, 1>::new(false),
-            StaticPixelDisplay::<SinglePixel, 1, 1>::new(true),
-            true,
-        );
-        assert!(overlay.is_ok());
+    mod overlay_widget {
+        use super::*;
+
+        #[test]
+        fn build_success() {
+            let overlay = OverlayWidget::build(
+                StaticPixelDisplay::<SinglePixel, 1, 1>::new(false),
+                StaticPixelDisplay::<SinglePixel, 1, 1>::new(true),
+                true,
+            );
+            assert!(overlay.is_ok());
+        }
+
+        #[test]
+        fn build_failure() {
+            let overlay = OverlayWidget::build(
+                StaticPixelDisplay::<SinglePixel, 1, 1>::new(false),
+                StaticPixelDisplay::<SinglePixel, 1, 2>::new(true),
+                true,
+            );
+            assert!(overlay.is_err());
+        }
+
+        #[test]
+        fn dimensions() {
+            let overlay = OverlayWidget::new(
+                StaticPixelDisplay::<SinglePixel, 37, 63>::new(false),
+                StaticPixelDisplay::<SinglePixel, 37, 63>::new(true),
+                true,
+            );
+            assert_eq!(overlay.get_width_characters(), 37);
+            assert_eq!(overlay.get_height_characters(), 63);
+        }
     }
 
-    #[test]
-    fn test_overlay_build_failure() {
-        let overlay = OverlayWidget::build(
-            StaticPixelDisplay::<SinglePixel, 1, 1>::new(false),
-            StaticPixelDisplay::<SinglePixel, 1, 2>::new(true),
-            true,
-        );
-        assert!(overlay.is_err());
+    mod horizontal_tiling {
+        use super::*;
+
+        #[test]
+        fn build_success() {
+            let overlay = HorizontalTilingWidget::build(
+                StaticPixelDisplay::<SinglePixel, 3, 10>::new(false),
+                StaticPixelDisplay::<SinglePixel, 2, 10>::new(true),
+            );
+            assert!(overlay.is_ok());
+        }
+
+        #[test]
+        fn build_failure() {
+            let overlay = HorizontalTilingWidget::build(
+                StaticPixelDisplay::<SinglePixel, 10, 3>::new(false),
+                StaticPixelDisplay::<SinglePixel, 10, 2>::new(true),
+            );
+            assert!(overlay.is_err());
+        }
+
+        #[test]
+        fn dimensions() {
+            let overlay = HorizontalTilingWidget::new(
+                StaticPixelDisplay::<SinglePixel, 37, 20>::new(false),
+                StaticPixelDisplay::<SinglePixel, 63, 20>::new(true),
+            );
+            assert_eq!(overlay.get_width_characters(), 100);
+            assert_eq!(overlay.get_height_characters(), 20);
+        }
     }
 
-    #[test]
-    fn test_overlay_dimensions() {
-        let overlay = OverlayWidget::new(
-            StaticPixelDisplay::<SinglePixel, 37, 63>::new(false),
-            StaticPixelDisplay::<SinglePixel, 37, 63>::new(true),
-            true,
-        );
-        assert_eq!(overlay.get_width_characters(), 37);
-        assert_eq!(overlay.get_height_characters(), 63);
-    }
+    mod vertical_tiling {
+        use super::*;
 
-    #[test]
-    fn test_horizontal_tiling_build_success() {
-        let overlay = HorizontalTilingWidget::build(
-            StaticPixelDisplay::<SinglePixel, 3, 10>::new(false),
-            StaticPixelDisplay::<SinglePixel, 2, 10>::new(true),
-        );
-        assert!(overlay.is_ok());
-    }
+        #[test]
+        fn build_success() {
+            let overlay = VerticalTilingWidget::build(
+                StaticPixelDisplay::<SinglePixel, 20, 5>::new(false),
+                StaticPixelDisplay::<SinglePixel, 20, 4>::new(true),
+            );
+            assert!(overlay.is_ok());
+        }
 
-    #[test]
-    fn test_horizontal_tiling_build_failure() {
-        let overlay = HorizontalTilingWidget::build(
-            StaticPixelDisplay::<SinglePixel, 10, 3>::new(false),
-            StaticPixelDisplay::<SinglePixel, 10, 2>::new(true),
-        );
-        assert!(overlay.is_err());
-    }
+        #[test]
+        fn build_failure() {
+            let overlay = VerticalTilingWidget::build(
+                StaticPixelDisplay::<SinglePixel, 5, 20>::new(false),
+                StaticPixelDisplay::<SinglePixel, 4, 20>::new(true),
+            );
+            assert!(overlay.is_err());
+        }
 
-    #[test]
-    fn test_horizontal_tiling_dimensions() {
-        let overlay = HorizontalTilingWidget::new(
-            StaticPixelDisplay::<SinglePixel, 37, 20>::new(false),
-            StaticPixelDisplay::<SinglePixel, 63, 20>::new(true),
-        );
-        assert_eq!(overlay.get_width_characters(), 100);
-        assert_eq!(overlay.get_height_characters(), 20);
-    }
-
-    #[test]
-    fn test_vertical_tiling_build_success() {
-        let overlay = VerticalTilingWidget::build(
-            StaticPixelDisplay::<SinglePixel, 20, 5>::new(false),
-            StaticPixelDisplay::<SinglePixel, 20, 4>::new(true),
-        );
-        assert!(overlay.is_ok());
-    }
-
-    #[test]
-    fn test_vertical_tiling_build_failure() {
-        let overlay = VerticalTilingWidget::build(
-            StaticPixelDisplay::<SinglePixel, 5, 20>::new(false),
-            StaticPixelDisplay::<SinglePixel, 4, 20>::new(true),
-        );
-        assert!(overlay.is_err());
-    }
-
-    #[test]
-    fn test_vertical_tiling_dimensions() {
-        let overlay = VerticalTilingWidget::new(
-            StaticPixelDisplay::<SinglePixel, 30, 45>::new(false),
-            StaticPixelDisplay::<SinglePixel, 30, 54>::new(true),
-        );
-        assert_eq!(overlay.get_width_characters(), 30);
-        assert_eq!(overlay.get_height_characters(), 99);
+        #[test]
+        fn dimensions() {
+            let overlay = VerticalTilingWidget::new(
+                StaticPixelDisplay::<SinglePixel, 30, 45>::new(false),
+                StaticPixelDisplay::<SinglePixel, 30, 54>::new(true),
+            );
+            assert_eq!(overlay.get_width_characters(), 30);
+            assert_eq!(overlay.get_height_characters(), 99);
+        }
     }
 }


### PR DESCRIPTION
Rename build to new in cases where errors can't logically occur.
Improve error handling on the character display, when wide characters span multiple rows.
Add unit tests to widgets and displays.
Remove erroneous Default derivation on character pixel.