### PR TITLE
Chore/clippy lints

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,11 +66,11 @@ jobs:
     # Allow dirty flag added for convinience. Be careful when auto-formatting is enabled.
     - name: Clippy apply suggestions
       if: env.AUTO_FORMAT == 'true'
-      run: RUSTFLAGS="-Dclippy::all" cargo +nightly clippy --all-targets --all-features --fix --allow-dirty -- -W clippy::pedantic -W clippy::nursery -W clippy::cargo
+      run: RUSTFLAGS="-Dclippy::all" cargo +nightly clippy --all-targets --all-features --fix --allow-dirty -- -W clippy::pedantic -W clippy::nursery -W clippy::cargo -A clippy::cast-precision-loss
 
     # Still need to run clippy as well, because cargo clippy fix makes errors into warnings. See: https://github.com/rust-lang/rust-clippy/discussions/9979
     - name: Clippy
-      run: RUSTFLAGS="-Dclippy::all" cargo +nightly clippy --all-targets --all-features -- -W clippy::pedantic -W clippy::nursery -W clippy::cargo
+      run: RUSTFLAGS="-Dclippy::all" cargo +nightly clippy --all-targets --all-features -- -W clippy::pedantic -W clippy::nursery -W clippy::cargo -A clippy::cast-precision-loss
 
     # Still need to run cargo +nightly test --doc as this is not included in the regular test command. See: https://github.com/rust-lang/cargo/issues/6669
     - name: Run tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,12 +163,20 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 name = "console-display"
 version = "0.1.0"
 dependencies = [
+ "console-display-macros",
  "crossterm",
  "image",
  "paste",
  "rand",
- "rust-console-display-macros",
  "unicode-width",
+]
+
+[[package]]
+name = "console-display-macros"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -824,14 +832,6 @@ name = "rgb"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
-
-[[package]]
-name = "rust-console-display-macros"
-version = "0.1.0"
-dependencies = [
- "quote",
- "syn",
-]
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["console", "terminal", "tui", "ui", "widget"]
 categories = ["command-line-interface", "gui", "graphics"]
 
 [dependencies]
-rust-console-display-macros = { path = "./rust-console-display-macros" }
+console-display-macros = { path = "./rust-console-display-macros" }
 crossterm = "0.28.1"
 paste = "1.0.15"
 rand = "0.8.5"

--- a/examples/game_of_life.rs
+++ b/examples/game_of_life.rs
@@ -44,7 +44,11 @@ fn main() {
 
     display.set_target_frame_rate(30.);
     display.set_on_update(move |disp, _| {
+        #[allow(clippy::cast_possible_truncation)]
+        #[allow(clippy::cast_possible_wrap)]
         let width = disp.get_width() as i32;
+        #[allow(clippy::cast_possible_truncation)]
+        #[allow(clippy::cast_possible_wrap)]
         let height = disp.get_height() as i32;
         for x in 0..width {
             for y in 0..height {
@@ -59,10 +63,12 @@ fn main() {
                         neighbors += 1;
                     }
                 }
+                #[allow(clippy::cast_sign_loss)]
                 let pixel = disp
                     .get_pixel(x as usize, y as usize)
                     .expect("Could not get pixel.");
 
+                #[allow(clippy::cast_sign_loss)]
                 let _ = disp.set_pixel(
                     x as usize,
                     y as usize,

--- a/examples/graphing.rs
+++ b/examples/graphing.rs
@@ -26,11 +26,7 @@ fn main() {
             PixelType,
             { DIMENSIONS.0 },
             { DIMENSIONS.1 },
-        >::new(RGBColor {
-            r: 0,
-            g: 0,
-            b: 0,
-        })));
+        >::new(RGBColor::BLACK)));
     display.set_uv_x_min(uv_x.0);
     display.set_uv_x_max(uv_x.1);
     display.set_uv_y_min(uv_y.0);
@@ -44,17 +40,7 @@ fn main() {
         for x in xs {
             let y = function(x);
 
-            this.draw_line(
-                old_x,
-                old_y,
-                x,
-                y,
-                RGBColor {
-                    r: 255,
-                    g: 255,
-                    b: 255,
-                },
-            );
+            this.draw_line(old_x, old_y, x, y, RGBColor::WHITE);
 
             old_x = x;
             old_y = y;

--- a/examples/image_render.rs
+++ b/examples/image_render.rs
@@ -25,7 +25,9 @@ use image::{
 
 fn main() {
     type PixelType = ColorOctPixel;
+    #[allow(clippy::cast_possible_truncation)]
     const WIDTH: u32 = PixelType::WIDTH as u32;
+    #[allow(clippy::cast_possible_truncation)]
     const HEIGHT: u32 = PixelType::HEIGHT as u32;
 
     let max_dimensions: (u32, u32) = (200, 160);
@@ -70,14 +72,14 @@ fn main() {
             padded_dimensions.0 > dimensions.0
         {
             for _ in 0..padded_dimensions.0 - dimensions.0 {
-                data.push(RGBColor { r: 0, g: 0, b: 0 });
+                data.push(RGBColor::BLACK);
             }
             pixel_index = 0;
         }
     }
     for _ in 0..padded_dimensions.1 - dimensions.1 {
         for _ in 0..padded_dimensions.0 {
-            data.push(RGBColor { r: 0, g: 0, b: 0 });
+            data.push(RGBColor::BLACK);
         }
     }
 

--- a/examples/snake.rs
+++ b/examples/snake.rs
@@ -94,12 +94,14 @@ fn main() {
         // place new segment in front (direction) of snake head
         snake.insert(
             0,
+            #[allow(clippy::cast_possible_truncation)]
+            #[allow(clippy::cast_possible_wrap)]
             (
-                (snake[0].0 as i128 + direction.0)
-                    .rem_euclid(map_display.get_width() as i128)
+                (snake[0].0 as i32 + direction.0)
+                    .rem_euclid(map_display.get_width() as i32)
                     as usize,
-                (snake[0].1 as i128 + direction.1)
-                    .rem_euclid(map_display.get_height() as i128)
+                (snake[0].1 as i32 + direction.1)
+                    .rem_euclid(map_display.get_height() as i32)
                     as usize,
             ),
         );

--- a/examples/snake.rs
+++ b/examples/snake.rs
@@ -31,44 +31,24 @@ use console_display::{
 use crossterm::event::KeyCode;
 use rand::Rng;
 
+#[allow(clippy::too_many_lines)]
 fn main() {
-    let background_color = RGBColor { r: 0, g: 0, b: 0 };
-    let snake_color = RGBColor { r: 0, g: 255, b: 0 };
-    let apple_color = RGBColor { r: 255, g: 0, b: 0 };
+    let background_color = RGBColor::BLACK;
+    let snake_color = RGBColor::GREEN;
+    let apple_color = RGBColor::RED;
 
     let mut disp = construct_display();
 
     let _ = disp.0.set_pixel(
         99,
         0,
-        &CharacterPixel::build(
-            '1',
-            Color::Color(RGBColor { r: 0, g: 0, b: 0 }),
-            Color::Color(RGBColor {
-                r: 255,
-                g: 255,
-                b: 255,
-            }),
-        )
-        .unwrap(),
+        &CharacterPixel::new::<'1'>(
+            Color::Color(RGBColor::BLACK),
+            Color::Color(RGBColor::WHITE),
+        ),
     );
 
-    let endscreen = &mut disp.1.1;
-
-    for (i, sym) in "You lost".chars().enumerate() {
-        endscreen
-            .set_pixel(
-                46 + i,
-                10,
-                &CharacterPixel::build(
-                    sym,
-                    Color::Default,
-                    Color::Default,
-                )
-                .expect("Could not construct character pixel."),
-            )
-            .expect("Could not set character pixel.");
-    }
+    initialize_end_screen(&mut disp.1.1);
 
     let mut fps = 10.;
     let mut score = 1;
@@ -76,41 +56,13 @@ fn main() {
     let mut snake: Vec<(usize, usize)>;
     let mut apple;
 
-    {
-        let map_display = &mut disp.1;
-
-        snake = vec![(
-            map_display.0.get_width() / 2,
-            map_display.0.get_height() / 2,
-        )];
-
-        map_display
-            .0
-            .set_pixel(snake[0].0, snake[0].1, snake_color)
-            .expect("Could not set pixel.");
-
-        apple = (
-            rand::thread_rng().gen_range(0..map_display.0.get_width()),
-            rand::thread_rng().gen_range(0..map_display.0.get_height()),
-        );
-
-        while snake.contains(&apple) {
-            apple = (
-                rand::thread_rng().gen_range(0..map_display.0.get_width()),
-                rand::thread_rng()
-                    .gen_range(0..map_display.0.get_height()),
-            );
-        }
-
-        map_display
-            .0
-            .set_pixel(apple.0, apple.1, apple_color)
-            .expect("Could not set pixel.");
-    }
+    (snake, apple) =
+        initialize_map(&mut disp.1.0, snake_color, apple_color);
 
     let mut lost = false;
 
     disp.set_target_frame_rate(fps);
+    // TODO: Extract closure into separate function
     disp.set_on_update(move |disp, latest_event| {
         if let Some(key_event) = latest_event {
             let KeyCode::Char(key) = key_event.code
@@ -143,11 +95,11 @@ fn main() {
         snake.insert(
             0,
             (
-                (snake[0].0 as i32 + direction.0)
-                    .rem_euclid(map_display.get_width() as i32)
+                (snake[0].0 as i128 + direction.0)
+                    .rem_euclid(map_display.get_width() as i128)
                     as usize,
-                (snake[0].1 as i32 + direction.1)
-                    .rem_euclid(map_display.get_height() as i32)
+                (snake[0].1 as i128 + direction.1)
+                    .rem_euclid(map_display.get_height() as i128)
                     as usize,
             ),
         );
@@ -160,12 +112,8 @@ fn main() {
                     0,
                     &CharacterPixel::build(
                         digit,
-                        Color::Color(RGBColor { r: 0, g: 0, b: 0 }),
-                        Color::Color(RGBColor {
-                            r: 255,
-                            g: 255,
-                            b: 255,
-                        }),
+                        Color::Color(RGBColor::BLACK),
+                        Color::Color(RGBColor::WHITE),
                     )
                     .unwrap(),
                 );
@@ -205,9 +153,9 @@ fn main() {
             snake.pop();
         }
 
-        let map_display = &mut disp.1.0;
         // place pixel at snake head
-        map_display
+        disp.1
+            .0
             .set_pixel(snake[0].0, snake[0].1, snake_color)
             .expect("Could not set pixel.");
 
@@ -242,18 +190,14 @@ fn construct_display() -> Display {
             CharacterDisplay::<_, 100, 1>::new(
                 CharacterPixel::build(
                     ' ',
-                    Color::Color(RGBColor { r: 0, g: 0, b: 0 }),
-                    Color::Color(RGBColor {
-                        r: 255,
-                        g: 255,
-                        b: 255,
-                    }),
+                    Color::Color(RGBColor::BLACK),
+                    Color::Color(RGBColor::WHITE),
                 )
                 .unwrap(),
             ),
             OverlayWidget::new(
                 StaticPixelDisplay::<ColorDualPixel, 100, 42>::new(
-                    RGBColor { r: 0, b: 0, g: 0 },
+                    RGBColor::BLACK,
                 ),
                 CharacterDisplay::<CharacterPixel, 100, 21>::new(
                     CharacterPixel::build(
@@ -301,4 +245,54 @@ fn construct_display() -> Display {
             ),
         ),
     ))
+}
+
+fn initialize_end_screen<const WIDTH: usize, const HEIGHT: usize>(
+    endscreen: &mut CharacterDisplay<CharacterPixel, WIDTH, HEIGHT>,
+) {
+    for (i, sym) in "You lost".chars().enumerate() {
+        endscreen
+            .set_pixel(
+                46 + i,
+                10,
+                &CharacterPixel::build(
+                    sym,
+                    Color::Default,
+                    Color::Default,
+                )
+                .expect("Could not construct character pixel."),
+            )
+            .expect("Could not set character pixel.");
+    }
+}
+
+fn initialize_map<const WIDTH: usize, const HEIGHT: usize>(
+    map_display: &mut StaticPixelDisplay<ColorDualPixel, WIDTH, HEIGHT>,
+    snake_color: RGBColor,
+    apple_color: RGBColor,
+) -> (Vec<(usize, usize)>, (usize, usize)) {
+    let snake =
+        vec![(map_display.get_width() / 2, map_display.get_height() / 2)];
+
+    map_display
+        .set_pixel(snake[0].0, snake[0].1, snake_color)
+        .expect("Could not set pixel.");
+
+    let mut apple = (
+        rand::thread_rng().gen_range(0..map_display.get_width()),
+        rand::thread_rng().gen_range(0..map_display.get_height()),
+    );
+
+    while snake.contains(&apple) {
+        apple = (
+            rand::thread_rng().gen_range(0..map_display.get_width()),
+            rand::thread_rng().gen_range(0..map_display.get_height()),
+        );
+    }
+
+    map_display
+        .set_pixel(apple.0, apple.1, apple_color)
+        .expect("Could not set pixel.");
+
+    (snake, apple)
 }

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -12,10 +12,10 @@ use console_display::{
 
 fn main() {
     let mut char_disp: CharacterDisplay<CharacterPixel, 40, 20> =
-        CharacterDisplay::new(
-            CharacterPixel::build('あ', Color::Default, Color::Default)
-                .unwrap(),
-        );
+        CharacterDisplay::new(CharacterPixel::new::<'あ'>(
+            Color::Default,
+            Color::Default,
+        ));
 
     let mut x = 0;
     let mut y = 0;

--- a/rust-console-display-macros/Cargo.toml
+++ b/rust-console-display-macros/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
-name = "rust-console-display-macros"
+name = "console-display-macros"
 version = "0.1.0"
 edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "Macros for the console-display crate."
+readme = "../README.md"
+repository = "https://github.com/RolandNeuber/rust-console-display"
+keywords = ["console-display", "macro"]
+categories = ["command-line-interface", "gui", "graphics"]
 
 [lib]
 proc-macro = true

--- a/rust-console-display-macros/src/lib.rs
+++ b/rust-console-display-macros/src/lib.rs
@@ -98,7 +98,7 @@ pub fn derive_two_widget(input: TokenStream) -> TokenStream {
 }
 
 fn add_static_widget_bound_to_t(mut generics: Generics) -> Generics {
-    for param in generics.params.iter_mut() {
+    for param in &mut generics.params {
         if let GenericParam::Type(type_param) = param &&
             type_param.ident == "T"
         {

--- a/src/display/character_display.rs
+++ b/src/display/character_display.rs
@@ -63,6 +63,7 @@ impl<const WIDTH: usize, const HEIGHT: usize>
     ///
     /// This function panics if the data generated from the fill does not match the dimensions of the display.
     /// This should not happen and is subject to change in the future.
+    #[must_use]
     pub fn new(fill: CharacterPixel) -> Self
     where
         [(); WIDTH * HEIGHT]:,

--- a/src/display/console_display.rs
+++ b/src/display/console_display.rs
@@ -200,6 +200,8 @@ pub trait ConsoleDisplay<T: Pixel>: DynamicWidget {
         let mut x = x1;
         let mut y = y1;
 
+        #[allow(clippy::cast_possible_truncation)]
+        #[allow(clippy::cast_sign_loss)]
         for _ in 0..=steps.round() as usize {
             if x >= 0. && y >= 0. {
                 let _ = self.set_pixel(

--- a/src/display/display_driver.rs
+++ b/src/display/display_driver.rs
@@ -86,7 +86,7 @@ impl<T: DynamicWidget> DisplayDriver<T> {
     /// It enters alternate screen mode,
     /// hides the cursor and disables line wrapping.
     ///
-    /// # Error
+    /// # Errors
     ///
     /// Returns an error when any on the actions above fail.
     /// Note that resizing the terminal does not fail, if the terminal does not support it.
@@ -100,8 +100,14 @@ impl<T: DynamicWidget> DisplayDriver<T> {
             stdout,
             terminal::EnterAlternateScreen, // use alternate screen
             terminal::SetSize(
-                self.get_child().get_width_characters() as u16,
-                self.get_child().get_height_characters() as u16
+                self.get_child()
+                    .get_width_characters()
+                    .try_into()
+                    .unwrap_or(u16::MAX),
+                self.get_child()
+                    .get_height_characters()
+                    .try_into()
+                    .unwrap_or(u16::MAX)
             ), // set dimensions of screen
             terminal::DisableLineWrap,      // disable line wrapping
             terminal::Clear(terminal::ClearType::All), // clear screen

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,7 +1,8 @@
 #[macro_export]
 macro_rules! impl_getters {
-    ($($visibility:vis $field:ident: $type:ty),*) => {
+    ($($(#[$attr:meta])* $visibility:vis $field:ident: $type:ty),*) => {
         $(
+            $(#[$attr])*
             $visibility fn $field(&self) -> &$type {
                 &self.$field
             }
@@ -33,9 +34,10 @@ macro_rules! impl_setters {
 
 #[macro_export]
 macro_rules! impl_new {
-    ($visibility:vis $struct:ident, $($arg:ident: $type:ty), *) => {
+    ($(#[$attr:meta])* $visibility:vis $struct:ident, $($arg:ident: $type:ty), *) => {
         //TODO: Refactor arguments
         #[allow(clippy::too_many_arguments)]
+        $(#[$attr])*
         $visibility fn new($($arg: $type),*) -> $struct {
             $struct {
                 $($arg), *

--- a/src/pixel/character_pixel.rs
+++ b/src/pixel/character_pixel.rs
@@ -45,6 +45,14 @@ impl Pixel for CharacterPixel {
 }
 
 impl CharacterPixel {
+    /// Constructs a character pixel from a char, a foreground and a background color.
+    ///
+    /// # Panics
+    ///
+    /// This function checks for control characters at compile time.
+    /// Panics when the compile time checks miss a control character.
+    /// This should not happen and is a implementation detail that is subject to change.
+    #[must_use]
     pub fn new<const CHARACTER: char>(
         foreground: Color,
         background: Color,
@@ -154,7 +162,7 @@ impl TryFrom<char> for CharacterPixel {
     type Error = String;
 
     fn try_from(value: char) -> Result<Self, Self::Error> {
-        CharacterPixel::build(value, Color::Default, Color::Default)
+        Self::build(value, Color::Default, Color::Default)
     }
 }
 
@@ -162,8 +170,8 @@ impl Default for CharacterPixelData {
     fn default() -> Self {
         Self {
             character: ' ',
-            foreground: Default::default(),
-            background: Default::default(),
+            foreground: Color::default(),
+            background: Color::default(),
             copy: false,
             width: 1,
         }

--- a/src/pixel/color_pixel.rs
+++ b/src/pixel/color_pixel.rs
@@ -55,7 +55,7 @@ impl Color {
 
 impl From<RGBColor> for Color {
     fn from(value: RGBColor) -> Self {
-        Color::Color(value)
+        Self::Color(value)
     }
 }
 
@@ -67,26 +67,26 @@ pub struct RGBColor {
 }
 
 impl RGBColor {
-    pub const BLACK: Self = RGBColor { r: 0, g: 0, b: 0 };
-    pub const WHITE: Self = RGBColor {
+    pub const BLACK: Self = Self { r: 0, g: 0, b: 0 };
+    pub const WHITE: Self = Self {
         r: 255,
         g: 255,
         b: 255,
     };
-    pub const RED: Self = RGBColor { r: 255, g: 0, b: 0 };
-    pub const GREEN: Self = RGBColor { r: 0, g: 255, b: 0 };
-    pub const BLUE: Self = RGBColor { r: 0, g: 0, b: 255 };
-    pub const YELLOW: Self = RGBColor {
+    pub const RED: Self = Self { r: 255, g: 0, b: 0 };
+    pub const GREEN: Self = Self { r: 0, g: 255, b: 0 };
+    pub const BLUE: Self = Self { r: 0, g: 0, b: 255 };
+    pub const YELLOW: Self = Self {
         r: 255,
         g: 255,
         b: 0,
     };
-    pub const CYAN: Self = RGBColor {
+    pub const CYAN: Self = Self {
         r: 0,
         g: 255,
         b: 255,
     };
-    pub const MAGENTA: Self = RGBColor {
+    pub const MAGENTA: Self = Self {
         r: 255,
         g: 0,
         b: 255,
@@ -95,9 +95,9 @@ impl RGBColor {
     #[rustfmt::skip]
     fn distance(color1: Self, color2: Self) -> f32 {
         (
-            (i32::from(color1.r) - i32::from(color2.r)).pow(2) as f32 +
-            (i32::from(color1.g) - i32::from(color2.g)).pow(2) as f32 +
-            (i32::from(color1.b) - i32::from(color2.b)).pow(2) as f32
+            f32::from((i16::from(color1.r) - i16::from(color2.r)).pow(2)) +
+            f32::from((i16::from(color1.g) - i16::from(color2.g)).pow(2)) +
+            f32::from((i16::from(color1.b) - i16::from(color2.b)).pow(2))
         )
         .sqrt()
     }
@@ -112,10 +112,15 @@ impl RGBColor {
             sum.1 += u32::from(color.g);
             sum.2 += u32::from(color.b);
         }
+        let Ok(colors_len) = u32::try_from(colors.len())
+        else {
+            return Err("colors contains too many elements");
+        };
+
         Ok(Self {
-            r: (sum.0 / colors.len() as u32) as u8,
-            g: (sum.1 / colors.len() as u32) as u8,
-            b: (sum.2 / colors.len() as u32) as u8,
+            r: (sum.0 / colors_len).clamp(0, 255) as u8,
+            g: (sum.1 / colors_len).clamp(0, 255) as u8,
+            b: (sum.2 / colors_len).clamp(0, 255) as u8,
         })
     }
 

--- a/src/pixel/color_pixel.rs
+++ b/src/pixel/color_pixel.rs
@@ -93,13 +93,14 @@ impl RGBColor {
     };
 
     #[rustfmt::skip]
+    #[allow(clippy::cast_possible_truncation)]
     fn distance(color1: Self, color2: Self) -> f32 {
         (
-            f32::from((i16::from(color1.r) - i16::from(color2.r)).pow(2)) +
-            f32::from((i16::from(color1.g) - i16::from(color2.g)).pow(2)) +
-            f32::from((i16::from(color1.b) - i16::from(color2.b)).pow(2))
+            f64::from((i32::from(color1.r) - i32::from(color2.r)).pow(2)) +
+            f64::from((i32::from(color1.g) - i32::from(color2.g)).pow(2)) +
+            f64::from((i32::from(color1.b) - i32::from(color2.b)).pow(2))
         )
-        .sqrt()
+        .sqrt() as f32
     }
 
     fn mix(colors: &[Self]) -> Result<Self, &str> {

--- a/src/pixel/monochrome_pixel.rs
+++ b/src/pixel/monochrome_pixel.rs
@@ -135,7 +135,7 @@ impl SinglePixel {
     /// assert_eq!(symbol, " ");
     ///
     /// ```
-    const fn get_char(&self) -> char {
+    const fn get_char(self) -> char {
         if self.pixels[0] { '█' } else { ' ' }
     }
 }
@@ -180,7 +180,7 @@ impl DualPixel {
     ];
 
     #[rustfmt::skip]
-    const fn index(&self) -> usize {
+    const fn index(self) -> usize {
         (self.pixels[0] as usize)      |
         (self.pixels[1] as usize) << 1
     }
@@ -216,7 +216,7 @@ impl DualPixel {
     /// assert_eq!(symbol, " ");
     ///
     /// ```
-    const fn get_char(&self) -> char {
+    const fn get_char(self) -> char {
         Self::CHARS[self.index()]
     }
 }
@@ -263,7 +263,7 @@ impl QuadPixel {
     ];
 
     #[rustfmt::skip]
-    const fn index(&self) -> usize {
+    const fn index(self) -> usize {
         (self.pixels[0] as usize)      |
         (self.pixels[1] as usize) << 1 |
         (self.pixels[2] as usize) << 2 |
@@ -292,7 +292,7 @@ impl QuadPixel {
     ///
     /// assert_eq!(symbol, "▚")
     /// ```
-    const fn get_char(&self) -> char {
+    const fn get_char(self) -> char {
         Self::CHARS[self.index()]
     }
 }
@@ -339,7 +339,7 @@ impl HexPixel {
     ];
 
     #[rustfmt::skip]
-    const fn index(&self) -> usize {
+    const fn index(self) -> usize {
         (self.pixels[0] as usize)      |
         (self.pixels[1] as usize) << 1 |
         (self.pixels[2] as usize) << 2 |
@@ -371,7 +371,7 @@ impl HexPixel {
     ///
     /// assert_eq!(symbol, "🬶")
     /// ```
-    const fn get_char(&self) -> char {
+    const fn get_char(self) -> char {
         Self::CHARS[self.index()]
     }
 }
@@ -430,7 +430,7 @@ impl OctPixel {
     ];
 
     #[rustfmt::skip]
-    const fn index(&self) -> usize {
+    const fn index(self) -> usize {
         (self.pixels[0] as usize)      |
         (self.pixels[1] as usize) << 1 |
         (self.pixels[2] as usize) << 2 |
@@ -464,7 +464,7 @@ impl OctPixel {
     ///
     /// assert_eq!(symbol, "𜴰")
     /// ```
-    const fn get_char(&self) -> char {
+    const fn get_char(self) -> char {
         Self::CHARS[self.index()]
     }
 }
@@ -519,7 +519,7 @@ impl BrailleOctPixel {
     ];
 
     #[rustfmt::skip]
-    const fn index(&self) -> usize {
+    const fn index(self) -> usize {
         (self.pixels[0] as usize)      |
         (self.pixels[1] as usize) << 1 |
         (self.pixels[2] as usize) << 2 |
@@ -554,7 +554,7 @@ impl BrailleOctPixel {
     ///
     /// assert_eq!(symbol, "⠵")
     /// ```
-    const fn get_char(&self) -> char {
+    const fn get_char(self) -> char {
         Self::CHARS[self.index()]
     }
 }

--- a/src/widget/single_widget.rs
+++ b/src/widget/single_widget.rs
@@ -14,7 +14,7 @@ use std::{
     },
 };
 
-use rust_console_display_macros::{
+use console_display_macros::{
     DynamicWidget,
     SingleWidget,
     StaticWidget,
@@ -236,6 +236,8 @@ impl<S: MultiPixel, const WIDTH: usize, const HEIGHT: usize>
         )
     }
 
+    #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::cast_sign_loss)]
     fn uv_to_texture(
         uv: f32,
         uv_min: f32,
@@ -576,7 +578,7 @@ pub struct BorderDefault {
 
 impl BorderDefault {
     impl_new!(
-        pub BorderDefault,
+        #[must_use] pub BorderDefault,
         top: CharacterPixel,
         top_left: CharacterPixel,
         left: CharacterPixel,
@@ -588,14 +590,14 @@ impl BorderDefault {
     );
 
     impl_getters!(
-        pub top: CharacterPixel,
-        pub top_left: CharacterPixel,
-        pub left: CharacterPixel,
-        pub bottom_left: CharacterPixel,
-        pub bottom: CharacterPixel,
-        pub bottom_right: CharacterPixel,
-        pub right: CharacterPixel,
-        pub top_right: CharacterPixel
+        #[must_use] pub top: CharacterPixel,
+        #[must_use] pub top_left: CharacterPixel,
+        #[must_use] pub left: CharacterPixel,
+        #[must_use] pub bottom_left: CharacterPixel,
+        #[must_use] pub bottom: CharacterPixel,
+        #[must_use] pub bottom_right: CharacterPixel,
+        #[must_use] pub right: CharacterPixel,
+        #[must_use] pub top_right: CharacterPixel
     );
 }
 
@@ -769,7 +771,7 @@ mod tests {
             assert_ne!(
                 buffer1.borrow()[0].to_string(),
                 buffer2.borrow()[0].to_string()
-            )
+            );
         }
     }
     mod padding_widget {
@@ -785,7 +787,7 @@ mod tests {
                 40,
             );
             assert_eq!(widget.get_width_characters(), 31);
-            assert_eq!(widget.get_height_characters(), 71)
+            assert_eq!(widget.get_height_characters(), 71);
         }
     }
 }

--- a/src/widget/single_widget.rs
+++ b/src/widget/single_widget.rs
@@ -663,7 +663,6 @@ impl<T: DynamicWidget, S: Border> DynamicWidget for BorderWidget<T, S> {
 }
 
 impl<T: DynamicWidget, S: Border> Display for BorderWidget<T, S> {
-    // TODO: Implement properly
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let width_chars = self.get_width_characters();
         let height_chars = self.get_height_characters();

--- a/src/widget/two_widget.rs
+++ b/src/widget/two_widget.rs
@@ -6,7 +6,7 @@ use std::{
     },
 };
 
-use rust_console_display_macros::{
+use console_display_macros::{
     StaticWidget,
     TwoWidget,
 };


### PR DESCRIPTION
- Remove "rust-" prefix from macro crate name
- Fix all clippy lints by either refactoring code or allowing the lint
