### PR TITLE
Feature/new overlay widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ use console_display::{
 // Set dimensions to 100 by 100 pixels (50 by 25 characters)
 // with a red fill.
 let disp = StaticPixelDisplay::<ColorOctPixel, 100, 100>::new(
-    color_pixel::RGBColor { r: 255, g: 0, b: 0 },
+    color_pixel::RGBColor::RED.into(),
 );
 
 // Wrap the display in a driver to manage interactions with the terminal

--- a/examples/game_of_life.rs
+++ b/examples/game_of_life.rs
@@ -46,26 +46,24 @@ fn main() {
     display.set_on_update(move |disp, _| {
         #[allow(clippy::cast_possible_truncation)]
         #[allow(clippy::cast_possible_wrap)]
-        let width = disp.get_width() as i32;
+        let width = disp.width() as i32;
         #[allow(clippy::cast_possible_truncation)]
         #[allow(clippy::cast_possible_wrap)]
-        let height = disp.get_height() as i32;
+        let height = disp.height() as i32;
         for x in 0..width {
             for y in 0..height {
                 let mut neighbors = 0;
                 for i in offsets {
                     let x_i = (x + i.0).rem_euclid(width) as usize;
                     let y_i = (y + i.1).rem_euclid(height) as usize;
-                    if disp
-                        .get_pixel(x_i, y_i)
-                        .expect("Could not get pixel.")
+                    if disp.pixel(x_i, y_i).expect("Could not get pixel.")
                     {
                         neighbors += 1;
                     }
                 }
                 #[allow(clippy::cast_sign_loss)]
                 let pixel = disp
-                    .get_pixel(x as usize, y as usize)
+                    .pixel(x as usize, y as usize)
                     .expect("Could not get pixel.");
 
                 #[allow(clippy::cast_sign_loss)]

--- a/examples/graphing.rs
+++ b/examples/graphing.rs
@@ -34,7 +34,7 @@ fn main() {
 
     display.set_on_update(|this: &mut DisplayDriver<_>, _| {
         let function = |x: f32| (x * x).sin();
-        let mut xs = this.get_x_values().collect::<Vec<_>>().into_iter();
+        let mut xs = this.x_values().collect::<Vec<_>>().into_iter();
         let mut old_x = xs.next().unwrap();
         let mut old_y = function(old_x);
         for x in xs {

--- a/examples/graphing.rs
+++ b/examples/graphing.rs
@@ -2,16 +2,26 @@
 #![feature(generic_const_exprs)]
 
 use console_display::{
+    character_display::CharacterDisplay,
+    console_display::ConsoleDisplay,
     display_driver::{
         DisplayDriver,
         UpdateStatus,
     },
-    pixel::color_pixel::{
-        ColorOctPixel,
-        RGBColor,
+    pixel::{
+        Pixel,
+        character_pixel::CharacterPixel,
+        color_pixel::{
+            ARGBColor,
+            ColorOctPixel,
+            RGBColor,
+        },
     },
     pixel_display::StaticPixelDisplay,
-    widget::single_widget::UvWidget,
+    widget::{
+        single_widget::UvWidget,
+        two_widget::OverlayWidget,
+    },
 };
 
 fn main() {
@@ -21,26 +31,78 @@ fn main() {
     let uv_x = (-10.0, 10.0);
     let uv_y = (2.0, -2.0);
 
-    let mut display =
-        DisplayDriver::new(UvWidget::new(StaticPixelDisplay::<
-            PixelType,
-            { DIMENSIONS.0 },
-            { DIMENSIONS.1 },
-        >::new(RGBColor::BLACK.into())));
-    display.set_uv_x_min(uv_x.0);
-    display.set_uv_x_max(uv_x.1);
-    display.set_uv_y_min(uv_y.0);
-    display.set_uv_y_max(uv_y.1);
+    let transparent = ARGBColor {
+        opacity: 63,
+        color: RGBColor::BLACK,
+    };
+
+    let mut axis: CharacterDisplay<
+        CharacterPixel,
+        { DIMENSIONS.0 / PixelType::WIDTH },
+        { DIMENSIONS.1 / PixelType::HEIGHT },
+    > = CharacterDisplay::new(CharacterPixel::new::<' '>(
+        transparent.into(),
+        transparent.into(),
+    ));
+    #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::cast_possible_wrap)]
+    axis.draw_line(
+        0,
+        (DIMENSIONS.1 / PixelType::HEIGHT) as i32 / 2,
+        (DIMENSIONS.0 / PixelType::WIDTH) as i32,
+        (DIMENSIONS.1 / PixelType::HEIGHT) as i32 / 2,
+        CharacterPixel::new::<'─'>(
+            RGBColor::WHITE.into(),
+            transparent.into(),
+        )
+        .into(),
+    );
+    #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::cast_possible_wrap)]
+    axis.draw_line(
+        (DIMENSIONS.0 / PixelType::WIDTH) as i32 / 2,
+        0,
+        (DIMENSIONS.0 / PixelType::WIDTH) as i32 / 2,
+        (DIMENSIONS.1 / PixelType::HEIGHT) as i32,
+        CharacterPixel::new::<'│'>(
+            RGBColor::WHITE.into(),
+            transparent.into(),
+        )
+        .into(),
+    );
+    axis.set_pixel(
+        DIMENSIONS.0 / PixelType::WIDTH / 2,
+        DIMENSIONS.1 / PixelType::HEIGHT / 2,
+        CharacterPixel::new::<'┼'>(
+            RGBColor::WHITE.into(),
+            transparent.into(),
+        )
+        .into(),
+    )
+    .unwrap();
+
+    let mut graph = UvWidget::new(StaticPixelDisplay::<
+        PixelType,
+        { DIMENSIONS.0 },
+        { DIMENSIONS.1 },
+    >::new(RGBColor::BLACK.into()));
+
+    graph.set_uv_x_min(uv_x.0);
+    graph.set_uv_x_max(uv_x.1);
+    graph.set_uv_y_min(uv_y.0);
+    graph.set_uv_y_max(uv_y.1);
+
+    let mut display = DisplayDriver::new(OverlayWidget::new(axis, graph));
 
     display.set_on_update(|this: &mut DisplayDriver<_>, _| {
         let function = |x: f32| (x * x).sin();
-        let mut xs = this.x_values().collect::<Vec<_>>().into_iter();
+        let mut xs = this.1.x_values().collect::<Vec<_>>().into_iter();
         let mut old_x = xs.next().unwrap();
         let mut old_y = function(old_x);
         for x in xs {
             let y = function(x);
 
-            this.draw_line(old_x, old_y, x, y, RGBColor::WHITE.into());
+            this.1.draw_line(old_x, old_y, x, y, RGBColor::WHITE.into());
 
             old_x = x;
             old_y = y;

--- a/examples/graphing.rs
+++ b/examples/graphing.rs
@@ -26,7 +26,7 @@ fn main() {
             PixelType,
             { DIMENSIONS.0 },
             { DIMENSIONS.1 },
-        >::new(RGBColor::BLACK)));
+        >::new(RGBColor::BLACK.into())));
     display.set_uv_x_min(uv_x.0);
     display.set_uv_x_max(uv_x.1);
     display.set_uv_y_min(uv_y.0);
@@ -40,7 +40,7 @@ fn main() {
         for x in xs {
             let y = function(x);
 
-            this.draw_line(old_x, old_y, x, y, RGBColor::WHITE);
+            this.draw_line(old_x, old_y, x, y, RGBColor::WHITE.into());
 
             old_x = x;
             old_y = y;

--- a/examples/image_render.rs
+++ b/examples/image_render.rs
@@ -62,11 +62,14 @@ fn main() {
         Vec::with_capacity((dimensions.0 * dimensions.1) as usize);
     let mut pixel_index = 0;
     for pixel in rgb.pixels() {
-        data.push(RGBColor {
-            r: pixel[0],
-            g: pixel[1],
-            b: pixel[2],
-        }.into());
+        data.push(
+            RGBColor {
+                r: pixel[0],
+                g: pixel[1],
+                b: pixel[2],
+            }
+            .into(),
+        );
         pixel_index += 1;
         if pixel_index == dimensions.0 &&
             padded_dimensions.0 > dimensions.0

--- a/examples/image_render.rs
+++ b/examples/image_render.rs
@@ -66,20 +66,20 @@ fn main() {
             r: pixel[0],
             g: pixel[1],
             b: pixel[2],
-        });
+        }.into());
         pixel_index += 1;
         if pixel_index == dimensions.0 &&
             padded_dimensions.0 > dimensions.0
         {
             for _ in 0..padded_dimensions.0 - dimensions.0 {
-                data.push(RGBColor::BLACK);
+                data.push(RGBColor::BLACK.into());
             }
             pixel_index = 0;
         }
     }
     for _ in 0..padded_dimensions.1 - dimensions.1 {
         for _ in 0..padded_dimensions.0 {
-            data.push(RGBColor::BLACK);
+            data.push(RGBColor::BLACK.into());
         }
     }
 

--- a/examples/snake.rs
+++ b/examples/snake.rs
@@ -11,7 +11,7 @@ use console_display::{
     pixel::{
         character_pixel::CharacterPixel,
         color_pixel::{
-            Color,
+            TerminalColor,
             ColorDualPixel,
             RGBColor,
         },
@@ -33,9 +33,9 @@ use rand::Rng;
 
 #[allow(clippy::too_many_lines)]
 fn main() {
-    let background_color = RGBColor::BLACK;
-    let snake_color = RGBColor::GREEN;
-    let apple_color = RGBColor::RED;
+    let background_color: TerminalColor = RGBColor::BLACK.into();
+    let snake_color: TerminalColor = RGBColor::GREEN.into();
+    let apple_color: TerminalColor = RGBColor::RED.into();
 
     let mut disp = construct_display();
 
@@ -43,8 +43,8 @@ fn main() {
         99,
         0,
         CharacterPixel::new::<'1'>(
-            Color::Color(RGBColor::BLACK),
-            Color::Color(RGBColor::WHITE),
+            TerminalColor::RGBColor(RGBColor::BLACK),
+            TerminalColor::RGBColor(RGBColor::WHITE),
         )
         .into(),
     );
@@ -115,8 +115,8 @@ fn main() {
                     0,
                     CharacterPixel::build(
                         digit,
-                        Color::Color(RGBColor::BLACK),
-                        Color::Color(RGBColor::WHITE),
+                        TerminalColor::RGBColor(RGBColor::BLACK),
+                        TerminalColor::RGBColor(RGBColor::WHITE),
                     )
                     .unwrap()
                     .into(),
@@ -191,20 +191,20 @@ fn construct_display() -> Display {
             CharacterDisplay::<_, 100, 1>::new(
                 CharacterPixel::build(
                     ' ',
-                    Color::Color(RGBColor::BLACK),
-                    Color::Color(RGBColor::WHITE),
+                    TerminalColor::RGBColor(RGBColor::BLACK),
+                    TerminalColor::RGBColor(RGBColor::WHITE),
                 )
                 .unwrap(),
             ),
             AlternativeWidget::new(
                 StaticPixelDisplay::<ColorDualPixel, 100, 42>::new(
-                    RGBColor::BLACK,
+                    RGBColor::BLACK.into(),
                 ),
                 CharacterDisplay::<CharacterPixel, 100, 21>::new(
                     CharacterPixel::build(
                         ' ',
-                        Color::Default,
-                        Color::Default,
+                        TerminalColor::Default,
+                        TerminalColor::Default,
                     )
                     .unwrap(),
                 ),
@@ -213,35 +213,35 @@ fn construct_display() -> Display {
         ),
         BorderDefault::new(
             CharacterPixel::new::<'═'>(
-                Color::Default,
+                TerminalColor::Default,
                 RGBColor::BLACK.into(),
             ),
             CharacterPixel::new::<'╔'>(
-                Color::Default,
+                TerminalColor::Default,
                 RGBColor::BLACK.into(),
             ),
             CharacterPixel::new::<'║'>(
-                Color::Default,
+                TerminalColor::Default,
                 RGBColor::BLACK.into(),
             ),
             CharacterPixel::new::<'╚'>(
-                Color::Default,
+                TerminalColor::Default,
                 RGBColor::BLACK.into(),
             ),
             CharacterPixel::new::<'═'>(
-                Color::Default,
+                TerminalColor::Default,
                 RGBColor::BLACK.into(),
             ),
             CharacterPixel::new::<'╝'>(
-                Color::Default,
+                TerminalColor::Default,
                 RGBColor::BLACK.into(),
             ),
             CharacterPixel::new::<'║'>(
-                Color::Default,
+                TerminalColor::Default,
                 RGBColor::BLACK.into(),
             ),
             CharacterPixel::new::<'╗'>(
-                Color::Default,
+                TerminalColor::Default,
                 RGBColor::BLACK.into(),
             ),
         ),
@@ -256,7 +256,7 @@ fn initialize_end_screen<const WIDTH: usize, const HEIGHT: usize>(
             .set_pixel(
                 46 + i,
                 10,
-                CharacterPixel::build(sym, Color::Default, Color::Default)
+                CharacterPixel::build(sym, TerminalColor::Default, TerminalColor::Default)
                     .expect("Could not construct character pixel.")
                     .into(),
             )
@@ -266,8 +266,8 @@ fn initialize_end_screen<const WIDTH: usize, const HEIGHT: usize>(
 
 fn initialize_map<const WIDTH: usize, const HEIGHT: usize>(
     map_display: &mut StaticPixelDisplay<ColorDualPixel, WIDTH, HEIGHT>,
-    snake_color: RGBColor,
-    apple_color: RGBColor,
+    snake_color: TerminalColor,
+    apple_color: TerminalColor,
 ) -> (Vec<(usize, usize)>, (usize, usize)) {
     let snake = vec![(map_display.width() / 2, map_display.height() / 2)];
 

--- a/examples/snake.rs
+++ b/examples/snake.rs
@@ -99,10 +99,10 @@ fn main() {
             #[allow(clippy::cast_possible_wrap)]
             (
                 (snake[0].0 as i32 + direction.0)
-                    .rem_euclid(map_display.get_width() as i32)
+                    .rem_euclid(map_display.width() as i32)
                     as usize,
                 (snake[0].1 as i32 + direction.1)
-                    .rem_euclid(map_display.get_height() as i32)
+                    .rem_euclid(map_display.height() as i32)
                     as usize,
             ),
         );
@@ -124,17 +124,14 @@ fn main() {
             }
 
             let map_display = &mut disp.1.0;
-            if score == map_display.get_width() * map_display.get_height()
-            {
+            if score == map_display.width() * map_display.height() {
                 return UpdateStatus::Break;
             }
             // place new apple
             while snake.contains(&apple) {
                 apple = (
-                    rand::thread_rng()
-                        .gen_range(0..map_display.get_width()),
-                    rand::thread_rng()
-                        .gen_range(0..map_display.get_height()),
+                    rand::thread_rng().gen_range(0..map_display.width()),
+                    rand::thread_rng().gen_range(0..map_display.height()),
                 );
             }
             map_display
@@ -272,22 +269,21 @@ fn initialize_map<const WIDTH: usize, const HEIGHT: usize>(
     snake_color: RGBColor,
     apple_color: RGBColor,
 ) -> (Vec<(usize, usize)>, (usize, usize)) {
-    let snake =
-        vec![(map_display.get_width() / 2, map_display.get_height() / 2)];
+    let snake = vec![(map_display.width() / 2, map_display.height() / 2)];
 
     map_display
         .set_pixel(snake[0].0, snake[0].1, snake_color)
         .expect("Could not set pixel.");
 
     let mut apple = (
-        rand::thread_rng().gen_range(0..map_display.get_width()),
-        rand::thread_rng().gen_range(0..map_display.get_height()),
+        rand::thread_rng().gen_range(0..map_display.width()),
+        rand::thread_rng().gen_range(0..map_display.height()),
     );
 
     while snake.contains(&apple) {
         apple = (
-            rand::thread_rng().gen_range(0..map_display.get_width()),
-            rand::thread_rng().gen_range(0..map_display.get_height()),
+            rand::thread_rng().gen_range(0..map_display.width()),
+            rand::thread_rng().gen_range(0..map_display.height()),
         );
     }
 

--- a/examples/snake.rs
+++ b/examples/snake.rs
@@ -23,7 +23,7 @@ use console_display::{
             BorderWidget,
         },
         two_widget::{
-            OverlayWidget,
+            AlternativeWidget,
             VerticalTilingWidget,
         },
     },
@@ -179,7 +179,7 @@ type Display = DisplayDriver<
     BorderWidget<
         VerticalTilingWidget<
             CharacterDisplay<CharacterPixel, 100, 1>,
-            OverlayWidget<
+            AlternativeWidget<
                 StaticPixelDisplay<ColorDualPixel, 100, 42>,
                 CharacterDisplay<CharacterPixel, 100, 21>,
             >,
@@ -199,7 +199,7 @@ fn construct_display() -> Display {
                 )
                 .unwrap(),
             ),
-            OverlayWidget::new(
+            AlternativeWidget::new(
                 StaticPixelDisplay::<ColorDualPixel, 100, 42>::new(
                     RGBColor::BLACK,
                 ),

--- a/examples/snake.rs
+++ b/examples/snake.rs
@@ -11,9 +11,9 @@ use console_display::{
     pixel::{
         character_pixel::CharacterPixel,
         color_pixel::{
-            TerminalColor,
             ColorDualPixel,
             RGBColor,
+            TerminalColor,
         },
     },
     pixel_display::StaticPixelDisplay,
@@ -43,8 +43,8 @@ fn main() {
         99,
         0,
         CharacterPixel::new::<'1'>(
-            TerminalColor::RGBColor(RGBColor::BLACK),
-            TerminalColor::RGBColor(RGBColor::WHITE),
+            TerminalColor::ARGBColor(RGBColor::BLACK.into()),
+            TerminalColor::ARGBColor(RGBColor::WHITE.into()),
         )
         .into(),
     );
@@ -115,8 +115,8 @@ fn main() {
                     0,
                     CharacterPixel::build(
                         digit,
-                        TerminalColor::RGBColor(RGBColor::BLACK),
-                        TerminalColor::RGBColor(RGBColor::WHITE),
+                        TerminalColor::ARGBColor(RGBColor::BLACK.into()),
+                        TerminalColor::ARGBColor(RGBColor::WHITE.into()),
                     )
                     .unwrap()
                     .into(),
@@ -191,8 +191,8 @@ fn construct_display() -> Display {
             CharacterDisplay::<_, 100, 1>::new(
                 CharacterPixel::build(
                     ' ',
-                    TerminalColor::RGBColor(RGBColor::BLACK),
-                    TerminalColor::RGBColor(RGBColor::WHITE),
+                    TerminalColor::ARGBColor(RGBColor::BLACK.into()),
+                    TerminalColor::ARGBColor(RGBColor::WHITE.into()),
                 )
                 .unwrap(),
             ),
@@ -256,9 +256,13 @@ fn initialize_end_screen<const WIDTH: usize, const HEIGHT: usize>(
             .set_pixel(
                 46 + i,
                 10,
-                CharacterPixel::build(sym, TerminalColor::Default, TerminalColor::Default)
-                    .expect("Could not construct character pixel.")
-                    .into(),
+                CharacterPixel::build(
+                    sym,
+                    TerminalColor::Default,
+                    TerminalColor::Default,
+                )
+                .expect("Could not construct character pixel.")
+                .into(),
             )
             .expect("Could not set character pixel.");
     }

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -36,12 +36,12 @@ fn main() {
             CharacterPixel::build(i, Color::Default, Color::Default)
                 .unwrap();
         let _ = char_disp.set_pixel(x, y, pixel.into());
-        if x + pixel.get_width() > char_disp.get_width() {
+        if x + pixel.width() > char_disp.width() {
             y += 1;
             x = 0;
         }
         else {
-            x += pixel.get_width();
+            x += pixel.width();
         }
     }
 

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -7,15 +7,15 @@ use console_display::{
     display_driver::DisplayDriver,
     pixel::{
         character_pixel::CharacterPixel,
-        color_pixel::Color,
+        color_pixel::TerminalColor,
     },
 };
 
 fn main() {
     let mut char_disp: CharacterDisplay<CharacterPixel, 40, 20> =
         CharacterDisplay::new(CharacterPixel::new::<'あ'>(
-            Color::Default,
-            Color::Default,
+            TerminalColor::Default,
+            TerminalColor::Default,
         ));
 
     let mut x = 0;
@@ -33,7 +33,7 @@ fn main() {
             continue;
         }
         let pixel =
-            CharacterPixel::build(i, Color::Default, Color::Default)
+            CharacterPixel::build(i, TerminalColor::Default, TerminalColor::Default)
                 .unwrap();
         let _ = char_disp.set_pixel(x, y, pixel.into());
         if x + pixel.width() > char_disp.width() {

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -32,9 +32,12 @@ fn main() {
             x = 0;
             continue;
         }
-        let pixel =
-            CharacterPixel::build(i, TerminalColor::Default, TerminalColor::Default)
-                .unwrap();
+        let pixel = CharacterPixel::build(
+            i,
+            TerminalColor::Default,
+            TerminalColor::Default,
+        )
+        .unwrap();
         let _ = char_disp.set_pixel(x, y, pixel.into());
         if x + pixel.width() > char_disp.width() {
             y += 1;

--- a/rust-console-display-macros/src/lib.rs
+++ b/rust-console-display-macros/src/lib.rs
@@ -45,7 +45,7 @@ pub fn derive_dynamic_widget(input: TokenStream) -> TokenStream {
         fn height_characters(&self) -> usize {
             self.child.height_characters()
         }
-        fn string_data(&self) -> Vec<Vec<String>> {
+        fn string_data(&self) -> Vec<Vec<DataCell>> {
             self.child.string_data()
         }
     }))
@@ -76,11 +76,11 @@ pub fn derive_single_widget(input: TokenStream) -> TokenStream {
             T: 'a,
             Self: 'a;
 
-        fn get_child(&self) -> Self::Borrowed<'_> {
+        fn child(&self) -> Self::Borrowed<'_> {
             &self.child
         }
 
-        fn get_child_mut(&mut self) -> Self::BorrowedMut<'_> {
+        fn child_mut(&mut self) -> Self::BorrowedMut<'_> {
             &mut self.child
         }
     }))

--- a/src/display/character_display.rs
+++ b/src/display/character_display.rs
@@ -189,7 +189,7 @@ impl<const WIDTH: usize, const HEIGHT: usize> Display
 
 #[cfg(test)]
 mod tests {
-    use crate::pixel::color_pixel::Color;
+    use crate::pixel::color_pixel::TerminalColor;
 
     use super::*;
 
@@ -200,8 +200,8 @@ mod tests {
                 vec![
                     CharacterPixel::build(
                         ' ',
-                        Color::Default,
-                        Color::Default,
+                        TerminalColor::Default,
+                        TerminalColor::Default,
                     )
                     .unwrap(),
                 ],
@@ -216,8 +216,8 @@ mod tests {
                 vec![
                     CharacterPixel::build(
                         ' ',
-                        Color::Default,
-                        Color::Default,
+                        TerminalColor::Default,
+                        TerminalColor::Default,
                     )
                     .unwrap();
                     8 * 10 - 1
@@ -233,8 +233,8 @@ mod tests {
                 vec![
                     CharacterPixel::build(
                         'あ',
-                        Color::Default,
-                        Color::Default,
+                        TerminalColor::Default,
+                        TerminalColor::Default,
                     )
                     .unwrap();
                     9 * 10 / 2

--- a/src/display/character_display.rs
+++ b/src/display/character_display.rs
@@ -5,6 +5,7 @@ use crate::{
     impl_display_for_dynamic_widget,
     pixel::character_pixel::CharacterPixel,
     widget::{
+        DataCell,
         DynamicWidget,
         StaticWidget,
     },
@@ -23,19 +24,19 @@ impl<const WIDTH: usize, const HEIGHT: usize>
     ConsoleDisplay<CharacterPixel>
     for CharacterDisplay<CharacterPixel, WIDTH, HEIGHT>
 {
-    fn get_width(&self) -> usize {
+    fn width(&self) -> usize {
         WIDTH
     }
 
-    fn get_height(&self) -> usize {
+    fn height(&self) -> usize {
         HEIGHT
     }
 
-    fn get_data(&self) -> &[CharacterPixel] {
+    fn data(&self) -> &[CharacterPixel] {
         &self.data
     }
 
-    fn get_data_mut(&mut self) -> &mut Box<[CharacterPixel]> {
+    fn data_mut(&mut self) -> &mut Box<[CharacterPixel]> {
         &mut self.data
     }
 }
@@ -51,7 +52,7 @@ impl<const WIDTH: usize, const HEIGHT: usize> DynamicWidget
         HEIGHT
     }
 
-    fn string_data(&self) -> Vec<Vec<String>> {
+    fn string_data(&self) -> Vec<Vec<DataCell>> {
         let mut result = Vec::new();
         let mut row = Vec::new();
         let mut width = 0;
@@ -65,15 +66,15 @@ impl<const WIDTH: usize, const HEIGHT: usize> DynamicWidget
             }
 
             if cell.is_copy() {
-                row.push(" ".to_string());
+                row.push(CharacterPixel::default().into());
                 width += 1;
                 continue;
             }
 
-            row.push(cell.to_string());
-            width += cell.get_width();
+            row.push((*cell).into());
+            width += cell.width();
 
-            for _ in 1..cell.get_width() {
+            for _ in 1..cell.width() {
                 iter.next();
             }
         }
@@ -100,7 +101,7 @@ impl<const WIDTH: usize, const HEIGHT: usize>
     where
         [(); WIDTH * HEIGHT]:,
     {
-        let character_width = fill.get_width();
+        let character_width = fill.width();
         let full_columns = WIDTH / character_width;
         let padding = WIDTH % character_width;
         let total_columns = full_columns + padding;
@@ -111,7 +112,7 @@ impl<const WIDTH: usize, const HEIGHT: usize>
         for i in 0..padding {
             for y in 0..HEIGHT {
                 let x = full_columns + i;
-                data[x + y * total_columns] = CharacterPixel::build(' ', fill.get_foreground(), fill.get_background())
+                data[x + y * total_columns] = CharacterPixel::build(' ', fill.foreground(), fill.background())
                     .expect("Invariant violated. Should not be a control character.");
             }
         }
@@ -133,11 +134,11 @@ impl<const WIDTH: usize, const HEIGHT: usize>
         let mut row_length = 0;
         for i in data {
             new_data.push(i);
-            for _ in 1..i.get_width() {
+            for _ in 1..i.width() {
                 new_data.push(i.make_copy());
             }
-            row_length += i.get_width();
-            if row_length > WIDTH && row_length - i.get_width() < WIDTH {
+            row_length += i.width();
+            if row_length > WIDTH && row_length - i.width() < WIDTH {
                 return Err(
                     "Data is malformed, character spans multiple rows."
                         .to_string(),
@@ -162,12 +163,12 @@ impl<const WIDTH: usize, const HEIGHT: usize>
     }
 
     #[must_use]
-    pub const fn get_width(&self) -> usize {
+    pub const fn width(&self) -> usize {
         WIDTH
     }
 
     #[must_use]
-    pub const fn get_height(&self) -> usize {
+    pub const fn height(&self) -> usize {
         HEIGHT
     }
 }

--- a/src/display/console_display.rs
+++ b/src/display/console_display.rs
@@ -5,9 +5,9 @@ use crate::{
 
 pub trait ConsoleDisplay<T: Pixel>: DynamicWidget {
     /// Returns the width of the display in a display specific, individually addressable unit (e.g. pixels, characters).
-    fn get_width(&self) -> usize;
+    fn width(&self) -> usize;
     /// Returns the height of the display in a display specific, individually addressable unit (e.g. pixels, characters).
-    fn get_height(&self) -> usize;
+    fn height(&self) -> usize;
 
     /// Returns a vector containing all the pixels in the display.
     ///
@@ -16,15 +16,14 @@ pub trait ConsoleDisplay<T: Pixel>: DynamicWidget {
     /// This function panics if the index of a pixel is out of bounds.
     /// This should not happen and is subject to change in the future.
     #[must_use]
-    fn get_pixels(&self) -> Vec<T::U>
+    fn pixels(&self) -> Vec<T::U>
     where
         [(); T::WIDTH * T::HEIGHT]:,
     {
-        let mut pixels =
-            Vec::with_capacity(self.get_width() * self.get_height());
-        for x in 0..self.get_width() {
-            for y in 0..self.get_height() {
-                pixels.push(self.get_pixel(x, y).expect(
+        let mut pixels = Vec::with_capacity(self.width() * self.height());
+        for x in 0..self.width() {
+            for y in 0..self.height() {
+                pixels.push(self.pixel(x, y).expect(
                     "Invariant violated, pixel index out of range.",
                 ));
             }
@@ -46,28 +45,27 @@ pub trait ConsoleDisplay<T: Pixel>: DynamicWidget {
     where
         [(); T::WIDTH * T::HEIGHT]:,
     {
-        if data.len() != self.get_width() * self.get_height() {
+        if data.len() != self.width() * self.height() {
             return Err(format!(
                 "Data does not match specified dimensions. Expected length of {}, got {}.",
-                self.get_width() * self.get_height(),
+                self.width() * self.height(),
                 data.len()
             ));
         }
-        for x in 0..self.get_width() {
-            for y in 0..self.get_height() {
-                self.set_pixel(x, y, data[x + y * self.get_width()])
-                    .expect(
-                        "Invariant violated, pixel index out of range.",
-                    );
+        for x in 0..self.width() {
+            for y in 0..self.height() {
+                self.set_pixel(x, y, data[x + y * self.width()]).expect(
+                    "Invariant violated, pixel index out of range.",
+                );
             }
         }
         Ok(())
     }
 
     #[must_use]
-    fn get_data(&self) -> &[T];
+    fn data(&self) -> &[T];
 
-    fn get_data_mut(&mut self) -> &mut Box<[T]>;
+    fn data_mut(&mut self) -> &mut Box<[T]>;
 
     /// Returns a bool representing the state of the pixel at the specified coordinate.
     ///
@@ -100,11 +98,11 @@ pub trait ConsoleDisplay<T: Pixel>: DynamicWidget {
     /// );
     /// // Replace with actual error handling
     ///
-    /// let pixel = disp.get_pixel(3, 2);
+    /// let pixel = disp.pixel(3, 2);
     ///
     /// assert_eq!(pixel, Ok(false));
     ///
-    /// let pixel = disp.get_pixel(5, 6);
+    /// let pixel = disp.pixel(5, 6);
     ///
     /// assert!(matches!(pixel, Err(_)));
     /// ```
@@ -117,11 +115,11 @@ pub trait ConsoleDisplay<T: Pixel>: DynamicWidget {
     ///
     /// If the index of a subpixel is out of bounds.
     /// This should not happen and is subject to change in the future.
-    fn get_pixel(&self, x: usize, y: usize) -> Result<T::U, String>
+    fn pixel(&self, x: usize, y: usize) -> Result<T::U, String>
     where
         [(); T::WIDTH * T::HEIGHT]:,
     {
-        if x >= self.get_width() || y >= self.get_height() {
+        if x >= self.width() || y >= self.height() {
             return Err(format!(
                 "Pixel coordinates out of bounds. Got x = {x}, y = {y}."
             ));
@@ -133,7 +131,7 @@ pub trait ConsoleDisplay<T: Pixel>: DynamicWidget {
         let offset_y: usize = y % T::HEIGHT;
 
         let pixel =
-            &self.get_data()[block_x + block_y * self.width_characters()];
+            &self.data()[block_x + block_y * self.width_characters()];
 
         Ok(pixel
             .subpixel(offset_x, offset_y)
@@ -159,7 +157,7 @@ pub trait ConsoleDisplay<T: Pixel>: DynamicWidget {
     where
         [(); T::WIDTH * T::HEIGHT]:,
     {
-        if x >= self.get_width() || y >= self.get_height() {
+        if x >= self.width() || y >= self.height() {
             return Err(format!(
                 "Pixel coordinates out of bounds. Got x = {x}, y = {y}."
             ));
@@ -172,7 +170,7 @@ pub trait ConsoleDisplay<T: Pixel>: DynamicWidget {
 
         let width_characters = self.width_characters();
         let pixel =
-            &mut self.get_data_mut()[block_x + block_y * width_characters];
+            &mut self.data_mut()[block_x + block_y * width_characters];
         pixel
             .set_subpixel(offset_x, offset_y, value)
             .expect("Offset should be 0 or 1.");

--- a/src/display/display_driver.rs
+++ b/src/display/display_driver.rs
@@ -100,11 +100,11 @@ impl<T: DynamicWidget> DisplayDriver<T> {
             stdout,
             terminal::EnterAlternateScreen, // use alternate screen
             terminal::SetSize(
-                self.get_child()
+                self.child()
                     .width_characters()
                     .try_into()
                     .unwrap_or(u16::MAX),
-                self.get_child()
+                self.child()
                     .height_characters()
                     .try_into()
                     .unwrap_or(u16::MAX)
@@ -117,19 +117,19 @@ impl<T: DynamicWidget> DisplayDriver<T> {
         Ok(())
     }
 
-    const fn get_original_width(&self) -> &u16 {
+    const fn original_width(&self) -> &u16 {
         &self.original_width
     }
 
-    const fn get_orignal_height(&self) -> &u16 {
+    const fn orignal_height(&self) -> &u16 {
         &self.original_height
     }
 
-    fn get_child(&self) -> &T {
+    fn child(&self) -> &T {
         &self.display
     }
 
-    fn get_child_mut(&mut self) -> &mut T {
+    fn child_mut(&mut self) -> &mut T {
         &mut self.display
     }
 
@@ -215,13 +215,13 @@ impl<T: DynamicWidget> Deref for DisplayDriver<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        self.get_child()
+        self.child()
     }
 }
 
 impl<T: DynamicWidget> DerefMut for DisplayDriver<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.get_child_mut()
+        self.child_mut()
     }
 }
 
@@ -237,14 +237,12 @@ impl<T: DynamicWidget> Drop for DisplayDriver<T> {
         );
 
         // reset dimensions of screen
-        if *self.get_original_width() != 0 &&
-            *self.get_orignal_height() != 0
-        {
+        if *self.original_width() != 0 && *self.orignal_height() != 0 {
             let _ = crossterm::execute!(
                 stdout,
                 terminal::SetSize(
-                    *self.get_original_width(),
-                    *self.get_orignal_height()
+                    *self.original_width(),
+                    *self.orignal_height()
                 )
             );
         }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -195,7 +195,7 @@ macro_rules! impl_display_for_dynamic_widget {
             let mut str_repr = String::new();
             for row in self.string_data() {
                 for cell in row {
-                    str_repr.push_str(&cell);
+                    str_repr.push_str(&cell.to_string());
                 }
                 str_repr.push_str("\r\n");
             }

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -1,10 +1,12 @@
 use std::fmt::Display;
 
+use crate::widget::DataCell;
+
 pub mod character_pixel;
 pub mod color_pixel;
 pub mod monochrome_pixel;
 
-pub trait Pixel: Display + Copy
+pub trait Pixel: Display + Copy + Into<DataCell>
 where
     Self: Sized,
 {

--- a/src/pixel/character_pixel.rs
+++ b/src/pixel/character_pixel.rs
@@ -7,6 +7,7 @@ use crate::{
     constraint,
     or,
     pixel::Pixel,
+    widget::DataCell,
 };
 
 use super::color_pixel::Color;
@@ -47,6 +48,16 @@ impl Pixel for CharacterPixel {
         &mut self,
     ) -> &mut [Self::U; Self::WIDTH * Self::HEIGHT] {
         &mut self.data
+    }
+}
+
+impl From<CharacterPixel> for DataCell {
+    fn from(val: CharacterPixel) -> Self {
+        Self {
+            character: val.character(),
+            foreground: val.foreground(),
+            background: val.background(),
+        }
     }
 }
 
@@ -115,17 +126,17 @@ impl CharacterPixel {
     }
 
     #[must_use]
-    pub const fn get_character(&self) -> char {
+    pub const fn character(&self) -> char {
         self.data[0].character
     }
 
     #[must_use]
-    pub const fn get_foreground(&self) -> Color {
+    pub const fn foreground(&self) -> Color {
         self.data[0].foreground
     }
 
     #[must_use]
-    pub const fn get_background(&self) -> Color {
+    pub const fn background(&self) -> Color {
         self.data[0].background
     }
 
@@ -139,7 +150,7 @@ impl CharacterPixel {
     }
 
     #[must_use]
-    pub const fn get_width(&self) -> usize {
+    pub const fn width(&self) -> usize {
         self.data[0].width
     }
 }
@@ -150,9 +161,9 @@ impl Display for CharacterPixel {
             f,
             "{}",
             Color::color(
-                self.get_character().to_string().as_str(),
-                &self.get_foreground(),
-                &self.get_background()
+                self.character().to_string().as_str(),
+                &self.foreground(),
+                &self.background()
             )
         )
     }
@@ -160,7 +171,7 @@ impl Display for CharacterPixel {
 
 impl Debug for CharacterPixel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", &self.get_character())
+        write!(f, "{}", &self.character())
     }
 }
 

--- a/src/pixel/character_pixel.rs
+++ b/src/pixel/character_pixel.rs
@@ -6,7 +6,7 @@ use std::fmt::{
 use crate::{
     constraint,
     or,
-    pixel::{color_pixel::Color, Pixel},
+    pixel::Pixel,
     widget::DataCell,
 };
 

--- a/src/pixel/character_pixel.rs
+++ b/src/pixel/character_pixel.rs
@@ -6,11 +6,11 @@ use std::fmt::{
 use crate::{
     constraint,
     or,
-    pixel::Pixel,
+    pixel::{color_pixel::Color, Pixel},
     widget::DataCell,
 };
 
-use super::color_pixel::Color;
+use super::color_pixel::TerminalColor;
 use unicode_width::UnicodeWidthChar;
 
 #[derive(Clone, Copy, Default)]
@@ -21,8 +21,8 @@ pub struct CharacterPixel {
 #[derive(Clone, Copy)]
 pub struct CharacterPixelData {
     character: char,
-    foreground: Color,
-    background: Color,
+    foreground: TerminalColor,
+    background: TerminalColor,
     copy: bool,
     width: usize,
 }
@@ -71,8 +71,8 @@ impl CharacterPixel {
     /// This should not happen and is a implementation detail that is subject to change.
     #[must_use]
     pub fn new<const CHARACTER: char>(
-        foreground: Color,
-        background: Color,
+        foreground: TerminalColor,
+        background: TerminalColor,
     ) -> Self
     where
         constraint!(CHARACTER >= '\u{20}'):, // Exclude C0 control chars
@@ -98,8 +98,8 @@ impl CharacterPixel {
     /// Returns an error if the character is a control character.
     pub fn build(
         character: char,
-        foreground: Color,
-        background: Color,
+        foreground: TerminalColor,
+        background: TerminalColor,
     ) -> Result<Self, String> {
         Ok(Self {
             data: [CharacterPixelData {
@@ -131,12 +131,12 @@ impl CharacterPixel {
     }
 
     #[must_use]
-    pub const fn foreground(&self) -> Color {
+    pub const fn foreground(&self) -> TerminalColor {
         self.data[0].foreground
     }
 
     #[must_use]
-    pub const fn background(&self) -> Color {
+    pub const fn background(&self) -> TerminalColor {
         self.data[0].background
     }
 
@@ -160,7 +160,7 @@ impl Display for CharacterPixel {
         write!(
             f,
             "{}",
-            Color::color(
+            TerminalColor::color(
                 self.character().to_string().as_str(),
                 &self.foreground(),
                 &self.background()
@@ -179,7 +179,7 @@ impl TryFrom<char> for CharacterPixel {
     type Error = String;
 
     fn try_from(value: char) -> Result<Self, Self::Error> {
-        Self::build(value, Color::Default, Color::Default)
+        Self::build(value, TerminalColor::Default, TerminalColor::Default)
     }
 }
 
@@ -187,8 +187,8 @@ impl Default for CharacterPixelData {
     fn default() -> Self {
         Self {
             character: ' ',
-            foreground: Color::default(),
-            background: Color::default(),
+            foreground: TerminalColor::default(),
+            background: TerminalColor::default(),
             copy: false,
             width: 1,
         }

--- a/src/pixel/monochrome_pixel.rs
+++ b/src/pixel/monochrome_pixel.rs
@@ -1,8 +1,9 @@
+// TODO: Deprecate monochrome pixel in favor of color pixel.
 use std::fmt::Display;
 
 use crate::pixel::{
     Pixel,
-    color_pixel::Color,
+    color_pixel::TerminalColor,
 };
 
 use crate::{
@@ -169,8 +170,8 @@ impl From<SinglePixel> for DataCell {
     fn from(val: SinglePixel) -> Self {
         Self {
             character: val.character(),
-            foreground: Color::Default,
-            background: Color::Default,
+            foreground: TerminalColor::Default,
+            background: TerminalColor::Default,
         }
     }
 }
@@ -259,8 +260,8 @@ impl From<DualPixel> for DataCell {
     fn from(val: DualPixel) -> Self {
         Self {
             character: val.character(),
-            foreground: Color::Default,
-            background: Color::Default,
+            foreground: TerminalColor::Default,
+            background: TerminalColor::Default,
         }
     }
 }
@@ -344,8 +345,8 @@ impl From<QuadPixel> for DataCell {
     fn from(val: QuadPixel) -> Self {
         Self {
             character: val.character(),
-            foreground: Color::Default,
-            background: Color::Default,
+            foreground: TerminalColor::Default,
+            background: TerminalColor::Default,
         }
     }
 }
@@ -432,8 +433,8 @@ impl From<HexPixel> for DataCell {
     fn from(val: HexPixel) -> Self {
         Self {
             character: val.character(),
-            foreground: Color::Default,
-            background: Color::Default,
+            foreground: TerminalColor::Default,
+            background: TerminalColor::Default,
         }
     }
 }
@@ -534,8 +535,8 @@ impl From<OctPixel> for DataCell {
     fn from(val: OctPixel) -> Self {
         Self {
             character: val.character(),
-            foreground: Color::Default,
-            background: Color::Default,
+            foreground: TerminalColor::Default,
+            background: TerminalColor::Default,
         }
     }
 }
@@ -633,8 +634,8 @@ impl From<BrailleOctPixel> for DataCell {
     fn from(val: BrailleOctPixel) -> Self {
         Self {
             character: val.character(),
-            foreground: Color::Default,
-            background: Color::Default,
+            foreground: TerminalColor::Default,
+            background: TerminalColor::Default,
         }
     }
 }

--- a/src/pixel/monochrome_pixel.rs
+++ b/src/pixel/monochrome_pixel.rs
@@ -1,12 +1,16 @@
 use std::fmt::Display;
 
-use crate::pixel::Pixel;
+use crate::pixel::{
+    Pixel,
+    color_pixel::Color,
+};
 
 use crate::{
     constraint,
     impl_getters,
     impl_getters_mut,
     impl_new,
+    widget::DataCell,
 };
 
 /// Specifies a block of pixels with specified dimensions.
@@ -105,8 +109,6 @@ pub struct SinglePixel {
 }
 
 impl SinglePixel {
-    /// See [`MultiPixel::get_char`] for details.
-    ///
     /// # Examples
     ///
     /// ```
@@ -135,7 +137,8 @@ impl SinglePixel {
     /// assert_eq!(symbol, " ");
     ///
     /// ```
-    const fn get_char(self) -> char {
+    #[must_use]
+    pub const fn character(self) -> char {
         if self.pixels[0] { '█' } else { ' ' }
     }
 }
@@ -158,7 +161,17 @@ impl MultiPixel for SinglePixel {
 
 impl Display for SinglePixel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.get_char())
+        write!(f, "{}", self.character())
+    }
+}
+
+impl From<SinglePixel> for DataCell {
+    fn from(val: SinglePixel) -> Self {
+        Self {
+            character: val.character(),
+            foreground: Color::Default,
+            background: Color::Default,
+        }
     }
 }
 
@@ -185,8 +198,6 @@ impl DualPixel {
         (self.pixels[1] as usize) << 1
     }
 
-    /// See [`MultiPixel::get_char`] for details.
-    ///
     /// # Examples
     ///
     /// ```
@@ -216,7 +227,8 @@ impl DualPixel {
     /// assert_eq!(symbol, " ");
     ///
     /// ```
-    const fn get_char(self) -> char {
+    #[must_use]
+    pub const fn character(self) -> char {
         Self::CHARS[self.index()]
     }
 }
@@ -239,7 +251,17 @@ impl MultiPixel for DualPixel {
 
 impl Display for DualPixel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.get_char())
+        write!(f, "{}", self.character())
+    }
+}
+
+impl From<DualPixel> for DataCell {
+    fn from(val: DualPixel) -> Self {
+        Self {
+            character: val.character(),
+            foreground: Color::Default,
+            background: Color::Default,
+        }
     }
 }
 
@@ -270,8 +292,6 @@ impl QuadPixel {
         (self.pixels[3] as usize) << 3
     }
 
-    /// See [`MultiPixel::get_char`] for details.
-    ///
     /// # Examples
     ///
     /// ```
@@ -292,14 +312,15 @@ impl QuadPixel {
     ///
     /// assert_eq!(symbol, "▚")
     /// ```
-    const fn get_char(self) -> char {
+    #[must_use]
+    pub const fn character(self) -> char {
         Self::CHARS[self.index()]
     }
 }
 
 impl Display for QuadPixel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.get_char())
+        write!(f, "{}", self.character())
     }
 }
 
@@ -317,6 +338,16 @@ impl Pixel for QuadPixel {
 
 impl MultiPixel for QuadPixel {
     impl_new!(QuadPixel, pixels: [bool; 4]);
+}
+
+impl From<QuadPixel> for DataCell {
+    fn from(val: QuadPixel) -> Self {
+        Self {
+            character: val.character(),
+            foreground: Color::Default,
+            background: Color::Default,
+        }
+    }
 }
 
 /// Specifies a block of pixels with dimensions 2 (width) by 3 (height).
@@ -348,8 +379,6 @@ impl HexPixel {
         (self.pixels[5] as usize) << 5
     }
 
-    /// See [`MultiPixel::get_char`] for details.
-    ///
     /// # Examples
     ///
     /// ```
@@ -371,7 +400,8 @@ impl HexPixel {
     ///
     /// assert_eq!(symbol, "🬶")
     /// ```
-    const fn get_char(self) -> char {
+    #[must_use]
+    pub const fn character(self) -> char {
         Self::CHARS[self.index()]
     }
 }
@@ -394,7 +424,17 @@ impl MultiPixel for HexPixel {
 
 impl Display for HexPixel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.get_char())
+        write!(f, "{}", self.character())
+    }
+}
+
+impl From<HexPixel> for DataCell {
+    fn from(val: HexPixel) -> Self {
+        Self {
+            character: val.character(),
+            foreground: Color::Default,
+            background: Color::Default,
+        }
     }
 }
 
@@ -441,8 +481,6 @@ impl OctPixel {
         (self.pixels[7] as usize) << 7
     }
 
-    /// See [`MultiPixel::get_char`] for details.
-    ///
     /// # Examples
     ///
     /// ```
@@ -464,7 +502,8 @@ impl OctPixel {
     ///
     /// assert_eq!(symbol, "𜴰")
     /// ```
-    const fn get_char(self) -> char {
+    #[must_use]
+    pub const fn character(self) -> char {
         Self::CHARS[self.index()]
     }
 }
@@ -487,7 +526,17 @@ impl MultiPixel for OctPixel {
 
 impl Display for OctPixel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.get_char())
+        write!(f, "{}", self.character())
+    }
+}
+
+impl From<OctPixel> for DataCell {
+    fn from(val: OctPixel) -> Self {
+        Self {
+            character: val.character(),
+            foreground: Color::Default,
+            background: Color::Default,
+        }
     }
 }
 
@@ -530,8 +579,6 @@ impl BrailleOctPixel {
         (self.pixels[7] as usize) << 7
     }
 
-    /// See [`MultiPixel::get_char`] for details.
-    ///
     /// # Examples
     ///
     /// ```
@@ -554,7 +601,8 @@ impl BrailleOctPixel {
     ///
     /// assert_eq!(symbol, "⠵")
     /// ```
-    const fn get_char(self) -> char {
+    #[must_use]
+    pub const fn character(self) -> char {
         Self::CHARS[self.index()]
     }
 }
@@ -577,6 +625,16 @@ impl MultiPixel for BrailleOctPixel {
 
 impl Display for BrailleOctPixel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.get_char())
+        write!(f, "{}", self.character())
+    }
+}
+
+impl From<BrailleOctPixel> for DataCell {
+    fn from(val: BrailleOctPixel) -> Self {
+        Self {
+            character: val.character(),
+            foreground: Color::Default,
+            background: Color::Default,
+        }
     }
 }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,5 +1,7 @@
 use std::fmt::Display;
 
+use crate::pixel::color_pixel::Color;
+
 pub mod single_widget;
 pub mod two_widget;
 
@@ -21,5 +23,26 @@ pub trait DynamicWidget: Display {
     /// The first vector contains rows.
     /// The vectors inside/rows contain individual characters.
     #[must_use]
-    fn string_data(&self) -> Vec<Vec<String>>;
+    fn string_data(&self) -> Vec<Vec<DataCell>>;
+}
+
+#[derive(Clone, Copy)]
+pub struct DataCell {
+    pub character: char,
+    pub foreground: Color,
+    pub background: Color,
+}
+
+impl Display for DataCell {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            Color::color(
+                &self.character.to_string(),
+                &self.foreground,
+                &self.background
+            )
+        )
+    }
 }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use crate::pixel::color_pixel::{Color, TerminalColor};
+use crate::pixel::color_pixel::TerminalColor;
 
 pub mod single_widget;
 pub mod two_widget;

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use crate::pixel::color_pixel::Color;
+use crate::pixel::color_pixel::{Color, TerminalColor};
 
 pub mod single_widget;
 pub mod two_widget;
@@ -29,8 +29,8 @@ pub trait DynamicWidget: Display {
 #[derive(Clone, Copy)]
 pub struct DataCell {
     pub character: char,
-    pub foreground: Color,
-    pub background: Color,
+    pub foreground: TerminalColor,
+    pub background: TerminalColor,
 }
 
 impl Display for DataCell {
@@ -38,7 +38,7 @@ impl Display for DataCell {
         write!(
             f,
             "{}",
-            Color::color(
+            TerminalColor::color(
                 &self.character.to_string(),
                 &self.foreground,
                 &self.background

--- a/src/widget/two_widget.rs
+++ b/src/widget/two_widget.rs
@@ -29,12 +29,12 @@ pub trait TwoWidget<S: DynamicWidget, T: DynamicWidget>:
 }
 
 #[derive(StaticWidget, TwoWidget)]
-pub struct OverlayWidget<S: DynamicWidget, T: DynamicWidget> {
+pub struct AlternativeWidget<S: DynamicWidget, T: DynamicWidget> {
     child1_on_top: bool,
     children: (S, T),
 }
 
-impl<S: StaticWidget, T: StaticWidget> OverlayWidget<S, T> {
+impl<S: StaticWidget, T: StaticWidget> AlternativeWidget<S, T> {
     pub const fn new(child1: S, child2: T, child1_on_top: bool) -> Self
     where
         constraint!(S::WIDTH_CHARACTERS == T::WIDTH_CHARACTERS):,
@@ -47,7 +47,7 @@ impl<S: StaticWidget, T: StaticWidget> OverlayWidget<S, T> {
     }
 }
 
-impl<S: DynamicWidget, T: DynamicWidget> OverlayWidget<S, T> {
+impl<S: DynamicWidget, T: DynamicWidget> AlternativeWidget<S, T> {
     /// Builds an overlay widget with two children.
     /// The `child1_on_top` parameter determines whether the first child should be
     /// on top or below the second child.
@@ -83,7 +83,7 @@ impl<S: DynamicWidget, T: DynamicWidget> OverlayWidget<S, T> {
 }
 
 impl<S: DynamicWidget, T: DynamicWidget> DynamicWidget
-    for OverlayWidget<S, T>
+    for AlternativeWidget<S, T>
 {
     fn width_characters(&self) -> usize {
         self.children.0.width_characters()
@@ -103,11 +103,11 @@ impl<S: DynamicWidget, T: DynamicWidget> DynamicWidget
     }
 }
 
-impl<S: DynamicWidget, T: DynamicWidget> Display for OverlayWidget<S, T> {
+impl<S: DynamicWidget, T: DynamicWidget> Display for AlternativeWidget<S, T> {
     impl_display_for_dynamic_widget!();
 }
 
-impl<S: DynamicWidget, T: DynamicWidget> Deref for OverlayWidget<S, T> {
+impl<S: DynamicWidget, T: DynamicWidget> Deref for AlternativeWidget<S, T> {
     type Target = (S, T);
 
     fn deref(&self) -> &Self::Target {
@@ -115,7 +115,7 @@ impl<S: DynamicWidget, T: DynamicWidget> Deref for OverlayWidget<S, T> {
     }
 }
 
-impl<S: DynamicWidget, T: DynamicWidget> DerefMut for OverlayWidget<S, T> {
+impl<S: DynamicWidget, T: DynamicWidget> DerefMut for AlternativeWidget<S, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.children
     }
@@ -300,6 +300,8 @@ impl<S: DynamicWidget, T: DynamicWidget> DerefMut
     }
 }
 
+
+
 #[cfg(test)]
 mod tests {
     use crate::{
@@ -314,7 +316,7 @@ mod tests {
 
         #[test]
         fn build_success() {
-            let overlay = OverlayWidget::build(
+            let overlay = AlternativeWidget::build(
                 StaticPixelDisplay::<SinglePixel, 1, 1>::new(false),
                 StaticPixelDisplay::<SinglePixel, 1, 1>::new(true),
                 true,
@@ -324,7 +326,7 @@ mod tests {
 
         #[test]
         fn build_failure() {
-            let overlay = OverlayWidget::build(
+            let overlay = AlternativeWidget::build(
                 StaticPixelDisplay::<SinglePixel, 1, 1>::new(false),
                 StaticPixelDisplay::<SinglePixel, 1, 2>::new(true),
                 true,
@@ -334,7 +336,7 @@ mod tests {
 
         #[test]
         fn dimensions() {
-            let overlay = OverlayWidget::new(
+            let overlay = AlternativeWidget::new(
                 StaticPixelDisplay::<SinglePixel, 37, 63>::new(false),
                 StaticPixelDisplay::<SinglePixel, 37, 63>::new(true),
                 true,

--- a/src/widget/two_widget.rs
+++ b/src/widget/two_widget.rs
@@ -16,7 +16,7 @@ use crate::{
     impl_display_for_dynamic_widget,
     impl_getters,
     impl_setters,
-    pixel::color_pixel::Color,
+    pixel::color_pixel::TerminalColor,
     widget::{
         DataCell,
         DynamicWidget,
@@ -374,9 +374,9 @@ impl<S: DynamicWidget, T: DynamicWidget> DynamicWidget
                     .zip(display_row)
                     .map(|(cell_top, cell_bottom)| {
                         let mut cell = cell_top;
-                        if cell.background == Color::Transparent {
+                        if cell.background == TerminalColor::Transparent {
                             cell.background = cell_bottom.background;
-                            if cell.foreground == Color::Transparent {
+                            if cell.foreground == TerminalColor::Transparent {
                                 cell.foreground = cell_bottom.foreground;
                             }
                         }
@@ -406,47 +406,51 @@ impl<S: DynamicWidget, T: DynamicWidget> DerefMut for OverlayWidget<S, T> {
     }
 }
 
+// TODO: Add more tests for functionality rather than initialization
 #[cfg(test)]
 mod tests {
     use crate::{
-        pixel::monochrome_pixel::SinglePixel,
+        pixel::{
+            monochrome_pixel::SinglePixel,
+            color_pixel::ColorSinglePixel,
+        },
         pixel_display::StaticPixelDisplay,
     };
 
     use super::*;
 
-    mod overlay_widget {
+    mod alternative_widget {
         use super::*;
 
         #[test]
         fn build_success() {
-            let overlay = AlternativeWidget::build(
+            let alternative = AlternativeWidget::build(
                 StaticPixelDisplay::<SinglePixel, 1, 1>::new(false),
                 StaticPixelDisplay::<SinglePixel, 1, 1>::new(true),
                 true,
             );
-            assert!(overlay.is_ok());
+            assert!(alternative.is_ok());
         }
 
         #[test]
         fn build_failure() {
-            let overlay = AlternativeWidget::build(
+            let alternative = AlternativeWidget::build(
                 StaticPixelDisplay::<SinglePixel, 1, 1>::new(false),
                 StaticPixelDisplay::<SinglePixel, 1, 2>::new(true),
                 true,
             );
-            assert!(overlay.is_err());
+            assert!(alternative.is_err());
         }
 
         #[test]
         fn dimensions() {
-            let overlay = AlternativeWidget::new(
+            let alternative = AlternativeWidget::new(
                 StaticPixelDisplay::<SinglePixel, 37, 63>::new(false),
                 StaticPixelDisplay::<SinglePixel, 37, 63>::new(true),
                 true,
             );
-            assert_eq!(overlay.width_characters(), 37);
-            assert_eq!(overlay.height_characters(), 63);
+            assert_eq!(alternative.width_characters(), 37);
+            assert_eq!(alternative.height_characters(), 63);
         }
     }
 
@@ -511,6 +515,48 @@ mod tests {
             );
             assert_eq!(overlay.width_characters(), 30);
             assert_eq!(overlay.height_characters(), 99);
+        }
+    }
+
+    mod overlay_widget {
+        use crate::pixel::color_pixel::RGBColor;
+
+        use super::*;
+
+        #[test]
+        fn build_success() {
+            let overlay = OverlayWidget::build(
+                StaticPixelDisplay::<SinglePixel, 1, 1>::new(false),
+                StaticPixelDisplay::<SinglePixel, 1, 1>::new(true),
+            );
+            assert!(overlay.is_ok());
+        }
+
+        #[test]
+        fn build_failure() {
+            let overlay = OverlayWidget::build(
+                StaticPixelDisplay::<SinglePixel, 1, 1>::new(false),
+                StaticPixelDisplay::<SinglePixel, 1, 2>::new(true),
+            );
+            assert!(overlay.is_err());
+        }
+
+        #[test]
+        fn dimensions() {
+            let overlay = OverlayWidget::new(
+                StaticPixelDisplay::<SinglePixel, 37, 63>::new(false),
+                StaticPixelDisplay::<SinglePixel, 37, 63>::new(true),
+            );
+            assert_eq!(overlay.width_characters(), 37);
+            assert_eq!(overlay.height_characters(), 63);
+        }
+
+        #[test]
+        fn transparency() {
+            let overlay = OverlayWidget::new(
+                StaticPixelDisplay::<ColorSinglePixel, 37, 63>::new(TerminalColor::Transparent),
+                StaticPixelDisplay::<ColorSinglePixel, 37, 63>::new(RGBColor::WHITE.into()),
+            );
         }
     }
 }


### PR DESCRIPTION
- Redesign color handling, replacing direct `RGBColor` usage with `TerminalColor`, add a `ARGBColor` to allow transparency and translucency
- Renamed various getters to not include the "get_"-prefix anymore
- `string_data` uses `DataCell` instead of `String` now for better usability 
- Significant refactor in `examples/graphing.rs` to introduce a overlay for drawing axis lines