### PR TITLE
Add const to macro calls wherever possible.

### DIFF
--- a/examples/text.rs
+++ b/examples/text.rs
@@ -10,11 +10,13 @@ use console_display::{
 };
 
 fn main() {
-    let mut char_disp: StaticCharacterDisplay<CharacterPixel, 40, 20> =
-        StaticCharacterDisplay::new(CharacterPixel::new::<'あ'>(
-            TerminalColor::Default,
-            TerminalColor::Default,
-        ));
+    let mut char_disp =
+        StaticCharacterDisplay::<CharacterPixel, 40, 20>::new(
+            CharacterPixel::new::<'あ'>(
+                TerminalColor::Default,
+                TerminalColor::Default,
+            ),
+        );
 
     let mut x = 0;
     let mut y = 0;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -26,6 +26,14 @@ macro_rules! impl_getters {
             }
         )*
     };
+    ($($(#[$attr:meta])* $visibility:vis const $field:ident: $type:ty),*) => {
+        $(
+            $(#[$attr])*
+            $visibility const fn $field(&self) -> &$type {
+                &self.$field
+            }
+        )*
+    };
 }
 
 /// Implements mutable getters for properties on a struct.
@@ -53,6 +61,13 @@ macro_rules! impl_getters_mut {
             }
         })*
     };
+    ($($visibility:vis const $field:ident: $type:ty),*) => {
+        $(paste::paste!{
+            $visibility const fn [<$field _mut>](&mut self) -> &mut $type {
+                &mut self.$field
+            }
+        })*
+    };
 }
 
 /// Implements setters for properties on a struct.
@@ -76,6 +91,13 @@ macro_rules! impl_setters {
     ($($visibility:vis $field:ident: $type:ty),*) => {
         $(paste::paste!{
             $visibility fn [<set_ $field>](&mut self, val: $type) {
+                self.$field = val;
+            }
+        })*
+    };
+    ($($visibility:vis const $field:ident: $type:ty),*) => {
+        $(paste::paste!{
+            $visibility const fn [<set_ $field>](&mut self, val: $type) {
                 self.$field = val;
             }
         })*
@@ -108,7 +130,7 @@ macro_rules! impl_setters {
 ///
 /// impl<T> GenericExample<T> {
 ///     impl_new!(
-///         pub GenericExample, <, T, >,
+///         pub GenericExample<T>,
 ///         flag: T,
 ///         data: [String; 8]
 ///     );
@@ -116,17 +138,17 @@ macro_rules! impl_setters {
 /// ```
 #[macro_export]
 macro_rules! impl_new {
-    ($(#[$attr:meta])* $visibility:vis $struct:ident, $($arg:ident: $type:ty), *) => {
-        #[allow(clippy::too_many_arguments)]
+    ($(#[$attr:meta])* $visibility:vis $struct:ident$(< $($generic:ty),* >)?, $($arg:ident: $type:ty), *) => {
         $(#[$attr])*
-        $visibility fn new($($arg: $type),*) -> $struct {
+        $visibility fn new($($arg: $type),*) -> $struct$(< $($generic),* >)?  {
             $struct {
                 $($arg), *
             }
         }
     };
-    ($visibility:vis $struct:ident, <, $($generic:ty), *, >, $($arg:ident: $type:ty), *) => {
-        $visibility fn new($($arg: $type),*) -> $struct<$($generic,)*> {
+    ($(#[$attr:meta])* $visibility:vis const $struct:ident$(< $($generic:ty),* >)?, $($arg:ident: $type:ty), *) => {
+        $(#[$attr])*
+        $visibility const fn new($($arg: $type),*) -> $struct$(< $($generic),* >)?  {
             $struct {
                 $($arg), *
             }

--- a/src/widget/single_widget.rs
+++ b/src/widget/single_widget.rs
@@ -80,7 +80,7 @@ impl<T: DynamicConsoleDisplay<S>, S: Pixel> UvWidget<T, S> {
 }
 
 impl<S: Pixel, T: DynamicConsoleDisplay<S> + StaticWidget> UvWidget<T, S> {
-    impl_setters!(pub uv_x_min: f32, pub uv_x_max: f32, pub uv_y_min: f32, pub uv_y_max: f32);
+    impl_setters!(pub const uv_x_min: f32, pub const uv_x_max: f32, pub const uv_y_min: f32, pub const uv_y_max: f32);
 
     /// Gets the pixel at the _uv_ coordinate (x, y).
     /// Using coordinates outside the uv mapping is considered
@@ -483,9 +483,9 @@ pub struct PaddingWidget<T: DynamicWidget> {
 }
 
 impl<T: DynamicWidget> PaddingWidget<T> {
-    impl_new!(pub PaddingWidget, <, T, >, child: T, padding_left: usize, padding_right: usize, padding_top: usize, padding_bottom: usize);
+    impl_new!(pub const PaddingWidget<T>, child: T, padding_left: usize, padding_right: usize, padding_top: usize, padding_bottom: usize);
 
-    impl_setters!(pub padding_left: usize, pub padding_right: usize, pub padding_top: usize, pub padding_bottom: usize);
+    impl_setters!(pub const padding_left: usize, pub const padding_right: usize, pub const padding_top: usize, pub const padding_bottom: usize);
 }
 
 impl<T: DynamicWidget> DynamicWidget for PaddingWidget<T> {
@@ -579,7 +579,8 @@ pub struct BorderDefault {
 
 impl BorderDefault {
     impl_new!(
-        #[must_use] pub BorderDefault,
+        #[allow(clippy::too_many_arguments)]
+        #[must_use] pub const BorderDefault,
         top: CharacterPixel,
         top_left: CharacterPixel,
         left: CharacterPixel,
@@ -591,14 +592,14 @@ impl BorderDefault {
     );
 
     impl_getters!(
-        #[must_use] pub top: CharacterPixel,
-        #[must_use] pub top_left: CharacterPixel,
-        #[must_use] pub left: CharacterPixel,
-        #[must_use] pub bottom_left: CharacterPixel,
-        #[must_use] pub bottom: CharacterPixel,
-        #[must_use] pub bottom_right: CharacterPixel,
-        #[must_use] pub right: CharacterPixel,
-        #[must_use] pub top_right: CharacterPixel
+        #[must_use] pub const top: CharacterPixel,
+        #[must_use] pub const top_left: CharacterPixel,
+        #[must_use] pub const left: CharacterPixel,
+        #[must_use] pub const bottom_left: CharacterPixel,
+        #[must_use] pub const bottom: CharacterPixel,
+        #[must_use] pub const bottom_right: CharacterPixel,
+        #[must_use] pub const right: CharacterPixel,
+        #[must_use] pub const top_right: CharacterPixel
     );
 
     /// # Errors
@@ -859,7 +860,7 @@ pub struct BorderWidget<T: DynamicWidget, S: Border> {
 }
 
 impl<T: DynamicWidget, S: Border> BorderWidget<T, S> {
-    impl_new!(pub BorderWidget, <, T, S, >, child: T, border: S);
+    impl_new!(pub const BorderWidget<T, S>, child: T, border: S);
 }
 
 impl<T: DynamicWidget, S: Border> DynamicWidget for BorderWidget<T, S> {
@@ -947,9 +948,9 @@ pub struct InsetWidget<T: DynamicWidget> {
 }
 
 impl<T: DynamicWidget> InsetWidget<T> {
-    impl_new!(pub InsetWidget, <, T, >, child: T, inset_left: usize, inset_right: usize, inset_top: usize, inset_bottom: usize);
+    impl_new!(pub const InsetWidget<T>, child: T, inset_left: usize, inset_right: usize, inset_top: usize, inset_bottom: usize);
 
-    impl_getters!(pub child: T);
+    impl_getters!(pub const child: T);
 }
 
 impl<T: DynamicWidget> DynamicWidget for InsetWidget<T> {

--- a/src/widget/two_widget.rs
+++ b/src/widget/two_widget.rs
@@ -80,9 +80,9 @@ impl<S: DynamicWidget, T: DynamicWidget> AlternativeWidget<S, T> {
         })
     }
 
-    impl_getters!(pub child1_on_top: bool);
+    impl_getters!(pub const child1_on_top: bool);
 
-    impl_setters!(pub child1_on_top: bool);
+    impl_setters!(pub const child1_on_top: bool);
 }
 
 impl<S: DynamicWidget, T: DynamicWidget> DynamicWidget


### PR DESCRIPTION
Const coverage is still not satisfying due to limitations of rust const evaluation.
Fixes #39 