### PR TITLE
Example/drawing

### DIFF
--- a/examples/drawing.rs
+++ b/examples/drawing.rs
@@ -1,0 +1,118 @@
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+#![allow(clippy::unwrap_used)]
+
+use std::{
+    array::from_fn,
+    io,
+};
+
+use console_display::{
+    color::RGBColor,
+    display_driver::{
+        DisplayDriver,
+        UpdateStatus,
+    },
+    drawing::{
+        DynamicCanvas,
+        Line,
+    },
+    pixel::{
+        Pixel,
+        color_pixel::{
+            ColorDualPixel,
+            ColorSinglePixel,
+        },
+    },
+    pixel_display::StaticPixelDisplay,
+    widget::two_widget::HorizontalTilingWidget,
+};
+use crossterm::event::{
+    EnableMouseCapture,
+    Event,
+    MouseEventKind,
+};
+
+type PixelType = ColorDualPixel;
+const WIDTH: usize = 80;
+const HEIGHT: usize = 80;
+fn main() {
+    let pixel_disp =
+        StaticPixelDisplay::<PixelType, WIDTH, HEIGHT>::new(
+            RGBColor::BLACK.into(),
+        );
+
+    let palette = StaticPixelDisplay::<
+        ColorSinglePixel,
+        3,
+        { HEIGHT / PixelType::HEIGHT },
+    >::new_from_data(&from_fn(|i| {
+        println!("{i}");
+        match i * 4 * PixelType::HEIGHT / 3 / HEIGHT {
+            0 => RGBColor::WHITE,
+            1 => RGBColor::RED,
+            2 => RGBColor::GREEN,
+            3 => RGBColor::BLUE,
+            _ => unreachable!(),
+        }
+        .into()
+    }));
+    // exit(0);
+
+    crossterm::execute!(io::stdout(), EnableMouseCapture).unwrap();
+
+    let mut display = DisplayDriver::new(HorizontalTilingWidget::new(
+        palette, pixel_disp,
+    ));
+
+    let mut last_pos: Option<(usize, usize)> = None;
+    let mut color = RGBColor::WHITE.into();
+    display.set_on_update(move |disp, event| {
+        if let Some(Event::Mouse(mouse_event)) = event {
+            let current_pos = (
+                ((mouse_event.column as usize * PixelType::WIDTH) *
+                    (WIDTH + 1) /
+                    (WIDTH - PixelType::WIDTH + 1))
+                    .saturating_sub(3),
+                (mouse_event.row as usize * PixelType::HEIGHT) *
+                    (HEIGHT + 1) /
+                    (HEIGHT - PixelType::HEIGHT + 1),
+            );
+            if let MouseEventKind::Down(_) = mouse_event.kind
+                && mouse_event.column < 3 {
+                    color = match mouse_event.row as usize *
+                        4 *
+                        PixelType::HEIGHT /
+                        HEIGHT
+                    {
+                        0 => RGBColor::WHITE,
+                        1 => RGBColor::RED,
+                        2 => RGBColor::GREEN,
+                        3 => RGBColor::BLUE,
+                        _ => unreachable!(),
+                    }
+                    .into();
+                }
+            if let MouseEventKind::Drag(_) = mouse_event.kind {
+                let _ =
+                    disp.1.set_pixel(current_pos.0, current_pos.1, color);
+
+                if let Some(last_pos) = last_pos {
+                    let line = Line {
+                        x1: current_pos.0 as f32,
+                        y1: current_pos.1 as f32,
+                        x2: last_pos.0 as f32,
+                        y2: last_pos.1 as f32,
+                    };
+                    disp.1.draw(&line, color);
+                }
+            }
+            last_pos = Some(current_pos);
+        }
+
+        UpdateStatus::Continue
+    });
+
+    display.initialize().expect("Could not initialize display.");
+    display.update().expect("Could not update display.");
+}

--- a/examples/drawing.rs
+++ b/examples/drawing.rs
@@ -29,6 +29,7 @@ use crossterm::event::{
     MouseEventKind,
 };
 
+// TODO: Fix mouse events, when terminal dimensions don't match application dimensions
 type PixelType = ColorDualPixel;
 const WIDTH: usize = 80;
 const HEIGHT: usize = 80;

--- a/examples/drawing.rs
+++ b/examples/drawing.rs
@@ -2,10 +2,7 @@
 #![feature(generic_const_exprs)]
 #![allow(clippy::unwrap_used)]
 
-use std::{
-    array::from_fn,
-    io,
-};
+use std::array::from_fn;
 
 use console_display::{
     color::RGBColor,
@@ -28,7 +25,6 @@ use console_display::{
     widget::two_widget::HorizontalTilingWidget,
 };
 use crossterm::event::{
-    EnableMouseCapture,
     Event,
     MouseEventKind,
 };
@@ -37,17 +33,15 @@ type PixelType = ColorDualPixel;
 const WIDTH: usize = 80;
 const HEIGHT: usize = 80;
 fn main() {
-    let pixel_disp =
-        StaticPixelDisplay::<PixelType, WIDTH, HEIGHT>::new(
-            RGBColor::BLACK.into(),
-        );
+    let pixel_disp = StaticPixelDisplay::<PixelType, WIDTH, HEIGHT>::new(
+        RGBColor::BLACK.into(),
+    );
 
     let palette = StaticPixelDisplay::<
         ColorSinglePixel,
         3,
         { HEIGHT / PixelType::HEIGHT },
     >::new_from_data(&from_fn(|i| {
-        println!("{i}");
         match i * 4 * PixelType::HEIGHT / 3 / HEIGHT {
             0 => RGBColor::WHITE,
             1 => RGBColor::RED,
@@ -57,9 +51,6 @@ fn main() {
         }
         .into()
     }));
-    // exit(0);
-
-    crossterm::execute!(io::stdout(), EnableMouseCapture).unwrap();
 
     let mut display = DisplayDriver::new(HorizontalTilingWidget::new(
         palette, pixel_disp,
@@ -78,21 +69,22 @@ fn main() {
                     (HEIGHT + 1) /
                     (HEIGHT - PixelType::HEIGHT + 1),
             );
-            if let MouseEventKind::Down(_) = mouse_event.kind
-                && mouse_event.column < 3 {
-                    color = match mouse_event.row as usize *
-                        4 *
-                        PixelType::HEIGHT /
-                        HEIGHT
-                    {
-                        0 => RGBColor::WHITE,
-                        1 => RGBColor::RED,
-                        2 => RGBColor::GREEN,
-                        3 => RGBColor::BLUE,
-                        _ => unreachable!(),
-                    }
-                    .into();
+            if let MouseEventKind::Down(_) = mouse_event.kind &&
+                mouse_event.column < 3
+            {
+                color = match mouse_event.row as usize *
+                    4 *
+                    PixelType::HEIGHT /
+                    HEIGHT
+                {
+                    0 => RGBColor::WHITE,
+                    1 => RGBColor::RED,
+                    2 => RGBColor::GREEN,
+                    3 => RGBColor::BLUE,
+                    _ => unreachable!(),
                 }
+                .into();
+            }
             if let MouseEventKind::Drag(_) = mouse_event.kind {
                 let _ =
                     disp.1.set_pixel(current_pos.0, current_pos.1, color);

--- a/examples/snake.rs
+++ b/examples/snake.rs
@@ -73,7 +73,8 @@ fn main() {
     disp.set_target_frame_rate(fps);
     // TODO: Extract closure into separate function
     disp.set_on_update(move |disp, latest_event| {
-        if let Some(key_event) = latest_event {
+        if let Some(crossterm::event::Event::Key(key_event)) = latest_event
+        {
             let KeyCode::Char(key) = key_event.code
             else {
                 return UpdateStatus::Continue;

--- a/examples/tic_tac_toe.rs
+++ b/examples/tic_tac_toe.rs
@@ -117,7 +117,7 @@ fn main() {
             return UpdateStatus::Continue;
         }
 
-        let Some(key_event) = latest_event
+        let Some(crossterm::event::Event::Key(key_event)) = latest_event
         else {
             return UpdateStatus::Continue;
         };

--- a/src/display/display_driver.rs
+++ b/src/display/display_driver.rs
@@ -18,6 +18,8 @@ use crossterm::{
     cursor,
     event::{
         self,
+        DisableMouseCapture,
+        EnableMouseCapture,
         Event,
         KeyCode,
         KeyModifiers,
@@ -111,6 +113,7 @@ impl<T: DynamicWidget> DisplayDriver<T> {
             terminal::DisableLineWrap,      // disable line wrapping
             terminal::Clear(terminal::ClearType::All), // clear screen
             cursor::Hide,                   // hide cursor blinking
+            EnableMouseCapture,             // capture muse movement
         )?;
 
         Ok(())
@@ -233,6 +236,7 @@ impl<T: DynamicWidget> Drop for DisplayDriver<T> {
             terminal::EnableLineWrap, // disable line wrapping
             terminal::LeaveAlternateScreen, // return to previous screen
             cursor::Show,             // show cursor blinking
+            DisableMouseCapture,      // end mouse capture
         );
 
         // reset dimensions of screen

--- a/src/display/display_driver.rs
+++ b/src/display/display_driver.rs
@@ -113,7 +113,7 @@ impl<T: DynamicWidget> DisplayDriver<T> {
             terminal::DisableLineWrap,      // disable line wrapping
             terminal::Clear(terminal::ClearType::All), // clear screen
             cursor::Hide,                   // hide cursor blinking
-            EnableMouseCapture,             // capture muse movement
+            EnableMouseCapture,             // capture mouse movement
         )?;
 
         Ok(())


### PR DESCRIPTION
Add drawing (paint-like) example to binaries.
Allow more events to be handled, besides key strokes.
Add mouse capturing to the display driver.